### PR TITLE
Added Flexirest to HTTP clients list

### DIFF
--- a/catalog/Web_Apps_Services_Interaction/http_clients.yml
+++ b/catalog/Web_Apps_Services_Interaction/http_clients.yml
@@ -28,3 +28,4 @@ projects:
   - persistent_httparty
   - http-requestor
   - htcp
+  - flexirest


### PR DESCRIPTION
I was unsure of the ordering of them (obviously I'd like it not to be the last one in the list), but I've added Flexirest - https://github.com/flexirest/flexirest