### PR TITLE
ruby_version_management: add ruby-install, remove rbfu

### DIFF
--- a/catalog/Developer_Tools/ruby_version_management.yml
+++ b/catalog/Developer_Tools/ruby_version_management.yml
@@ -1,10 +1,10 @@
 name: Ruby Version Management
 description:
 projects:
-  - sstephenson/rbenv
-  - rvm
-  - sstephenson/ruby-build
   - postmodern/chruby
-  - pik
-  - senny/rvm.el
   - postmodern/ruby-install
+  - rvm/rvm
+  - senny/rvm.el
+  - sstephenson/rbenv
+  - sstephenson/ruby-build
+  - vertiginous/pik

--- a/catalog/Developer_Tools/ruby_version_management.yml
+++ b/catalog/Developer_Tools/ruby_version_management.yml
@@ -7,4 +7,3 @@ projects:
   - senny/rvm.el
   - sstephenson/rbenv
   - sstephenson/ruby-build
-  - vertiginous/pik

--- a/catalog/Developer_Tools/ruby_version_management.yml
+++ b/catalog/Developer_Tools/ruby_version_management.yml
@@ -7,5 +7,5 @@ projects:
   - postmodern/chruby
   - pik
   - senny/rvm.el
-  - hmans/rbfu
   - which_ruby
+  - postmodern/ruby-install

--- a/catalog/Developer_Tools/ruby_version_management.yml
+++ b/catalog/Developer_Tools/ruby_version_management.yml
@@ -7,5 +7,4 @@ projects:
   - postmodern/chruby
   - pik
   - senny/rvm.el
-  - which_ruby
   - postmodern/ruby-install

--- a/catalog/Developer_Tools/ruby_version_management.yml
+++ b/catalog/Developer_Tools/ruby_version_management.yml
@@ -1,9 +1,15 @@
 name: Ruby Version Management
 description:
 projects:
+  # deprecated in favor of chruby:
+  - hmans/rbfu
+  # deprecated
+  - phoet/which_ruby
   - postmodern/chruby
   - postmodern/ruby-install
   - rvm/rvm
   - senny/rvm.el
   - sstephenson/rbenv
   - sstephenson/ruby-build
+  # deprecated in favor of https://bitbucket.org/jonforums/uru
+  - vertiginous/pik


### PR DESCRIPTION
Adds `ruby-install` which is from the same author as `chruby` and works well together with it.

Removes `rbfu` as @hmans deprecated it in the favor of `chruby` some years ago.

---

- [x] We should ask @phoet if it's worth to keep the `which-ruby` gem around?

---

- [x] @colszowka personally I would keep those lists alphabetically sorted. Apart from an initially higher chance of merge conflicts, is there anything why you would not want to do that?