### PR TITLE
Active Record Bit Fields (4)

### DIFF
--- a/catalog/Active_Record_Plugins/Active_Record_Bit_Fields.yml
+++ b/catalog/Active_Record_Plugins/Active_Record_Bit_Fields.yml
@@ -1,7 +1,7 @@
 name: Active Record Bit Fields
 description: Use an integer field to store a set of booleans using bitwise logic
 projects:
-  - flag_shih_tzu
   - bitfields
-  - has-bit-field
   - bitmask_attributes
+  - flag_shih_tzu
+  - has-bit-field

--- a/catalog/Active_Record_Plugins/Active_Record_Bit_Fields.yml
+++ b/catalog/Active_Record_Plugins/Active_Record_Bit_Fields.yml
@@ -1,0 +1,7 @@
+name: Active Record Bit Fields
+description: Use an integer field to store a set of booleans using bitwise logic
+projects:
+  - flag_shih_tzu
+  - bitfields
+  - has-bit-field
+  - bitmask_attributes


### PR DESCRIPTION
Is there a way to add a new category?  The following gems would all go into an Active Record Bit Fields Category.
- flag_shih_tzu
- bitfields
- has-bit-field
- bitmask_attributes