### PR TITLE
New subcategory: JWT

### DIFF
--- a/catalog/Security/jwt.yml
+++ b/catalog/Security/jwt.yml
@@ -1,0 +1,6 @@
+name: JSON Web Tokens (JWTs)
+description: 
+projects:
+  - json-jwt
+  - json_web_token
+  - jwt

--- a/catalog/Security/security_tools.yml
+++ b/catalog/Security/security_tools.yml
@@ -5,7 +5,6 @@ projects:
   - alpaca
   - brakeman
   - codesake-dawn
-  - json-jwt
   - loofah
   - look/xss_terminate
   - mhartl/find_mass_assignment


### PR DESCRIPTION
[JWT.io](https://jwt.io/#libraries) lists 3 separate Ruby gems for processing JSON Web Tokens.

1. These 3 gems serve the same purpose. Do you agree JWT deserves its own subcategory?
2. Do you think **Security** is the right category, or might this make more sense living under **Web Apps, Services & Interaction**? My gut says **Security** since JWT is for ensuring the integrity of messages, especially around authentication, but on the other hand, JWT us useless without services interacting. I could see this going either way. **Security** falls in line with where the `json-jwt` entry was previously.
3. I suggested the name **JSON Web Tokens (JWTs)**, providing both the full name and acronym, and pluralizing them as is commonly done. Is that fine, or would you change anything?