### PR TITLE
Clean up gone github-only projects

### DIFF
--- a/catalog/Active_Record_Plugins/Active_Record_User_Stamping.yml
+++ b/catalog/Active_Record_Plugins/Active_Record_User_Stamping.yml
@@ -1,9 +1,8 @@
 name: Active Record User Stamping
-description: 
+description:
 projects:
   - acts_as_audited
   - ar-audit-tracer
-  - centro/tracktor
   - darcy/acts_as_loggable
   - grosser/record_activities
   - jnunemaker/user_stamp

--- a/catalog/Active_Record_Plugins/pagination.yml
+++ b/catalog/Active_Record_Plugins/pagination.yml
@@ -1,5 +1,5 @@
 name: Pagination
-description: 
+description:
 projects:
   - ajax_pagination
   - kaminari
@@ -8,4 +8,3 @@ projects:
   - simply_paginate
   - sorted
   - will_paginate
-  - willian/has_paginate

--- a/catalog/Background_Processing/daemonizing.yml
+++ b/catalog/Background_Processing/daemonizing.yml
@@ -1,5 +1,5 @@
 name: Daemonizing
-description: 
+description:
 projects:
   - daemon-kit
   - daemonizer
@@ -10,7 +10,6 @@ projects:
   - fallen
   - foreverb
   - looper
-  - peritor/backdrop
   - robustthread
   - simple-daemon
   - titan

--- a/catalog/Communication/Asynchronous_E-Mail.yml
+++ b/catalog/Communication/Asynchronous_E-Mail.yml
@@ -1,7 +1,7 @@
 name: Asynchronous E-Mail
-description: 
+description:
 projects:
-  - fnando/mail_queue
+  - jusnavigandi/mail_queue
   - mailhopper
   - popthis
   - resque_mail_queue

--- a/catalog/Communication/crm_apps.yml
+++ b/catalog/Communication/crm_apps.yml
@@ -1,11 +1,10 @@
 name: CRM Apps
-description: 
+description:
 projects:
   - alchemy_crm
-  - bitzesty/mongo_crm
   - brobertsaz/railscrm
   - djcp/cohort
-  - fatfreecrm/fat_free_crm
+  - fat_free_crm
   - myitcrm/myitcrm2
   - nutshell-crm
   - thomasn/forgetmenot

--- a/catalog/Communication/forum_systems.yml
+++ b/catalog/Communication/forum_systems.yml
@@ -1,8 +1,8 @@
 name: Forum Systems
-description: 
+description:
 projects:
-  - courtenay/altered_beast
   - engagecsm
+  - forem
   - forum_monster
-  - jayroh/thredded
-  - radar/forem
+  - jonthewayne/altered_beast
+  - thredded

--- a/catalog/Developer_Tools/project_management.yml
+++ b/catalog/Developer_Tools/project_management.yml
@@ -1,14 +1,14 @@
 name: Project Management
-description: 
+description:
 projects:
-  - bluescripts/reru_scrum
-  - bluescripts/taskrey
   - branston
   - chiliproject/chiliproject
   - dim/retrospectiva
   - edavis10/redmine
   - git_time_extractor
   - gitlabhq/gitlabhq
+  - joshrendek/reru_scrum
+  - joshrendek/taskrey
   - malclocke/fulcrum
   - pickler
   - shingara/oupsnow

--- a/catalog/JavaScript/rails_in_place_editing.yml
+++ b/catalog/JavaScript/rails_in_place_editing.yml
@@ -1,5 +1,5 @@
 name: Rails In-Place Editing
-description: 
+description:
 projects:
   - amerine/in_place_editing
   - best_in_place
@@ -15,4 +15,3 @@ projects:
   - redlinesoftware/in_place_editor
   - simplificator/inplace
   - stepheneb/in_place_rich_editing
-  - yizzreel/jquery_edit_in_place

--- a/catalog/Maintenance_Monitoring/server_monitoring.yml
+++ b/catalog/Maintenance_Monitoring/server_monitoring.yml
@@ -1,5 +1,5 @@
 name: Server Monitoring
-description: 
+description:
 projects:
   - amnesia
   - bluepill
@@ -8,10 +8,10 @@ projects:
   - health_checker
   - health_monitor
   - health_rails
-  - martinrusev/amonlite
   - nagios_check
   - new_relic_ping
   - outpost
+  - ramon
   - sensu
   - visage-app
   - webstats

--- a/catalog/Rails_Plugins/rails_app_templates.yml
+++ b/catalog/Rails_Plugins/rails_app_templates.yml
@@ -1,5 +1,5 @@
 name: Rails App Templates
-description: 
+description:
 projects:
   - appscrolls
   - appsta
@@ -9,7 +9,6 @@ projects:
   - icebreaker
   - imajes/rails-template
   - jm/rails-templates
-  - pivotal/guiderails
   - prologue
   - rails_apps_composer
   - rails_templater

--- a/catalog/Testing/A_B_Testing.yml
+++ b/catalog/Testing/A_B_Testing.yml
@@ -1,10 +1,10 @@
 name: A/B Testing
-description: 
+description:
 projects:
+  - abingo
   - abingo_port
   - absurdity
   - bandit
-  - bryanwoods/ABingo
   - fluidfeatures
   - fluidfeatures-rails
   - paulmars/seven_minute_abs

--- a/catalog/Testing/rails_fixture_replacement.yml
+++ b/catalog/Testing/rails_fixture_replacement.yml
@@ -1,6 +1,7 @@
 name: Rails Fixture Replacement
-description: 
+description:
 projects:
+  - blueprints
   - dm-sweatshop
   - fabrication
   - factory_girl
@@ -12,6 +13,5 @@ projects:
   - object_daddy
   - seedomatic
   - sham
-  - sinsiliux/Blueprints
   - spawn
   - transactionata

--- a/catalog/Time_Space/calendars.yml
+++ b/catalog/Time_Space/calendars.yml
@@ -1,13 +1,13 @@
 name: Calendars
-description: 
+description:
 projects:
   - calendar_helper
   - calendrier
-  - dmix/weekly_builder
   - event_cal
   - event_calendar
   - fnando/has_calendar
   - icalendar
   - later_dude
+  - namxam/weekly_builder
   - ri_cal
   - selene

--- a/catalog/Web_Apps_Services_Interaction/api_clients.yml
+++ b/catalog/Web_Apps_Services_Interaction/api_clients.yml
@@ -1,5 +1,5 @@
 name: API Clients
-description: 
+description:
 projects:
   - amazon-ecs
   - amazon-product-advertising-api
@@ -8,11 +8,10 @@ projects:
   - asin
   - bitly
   - clickatell
-  - coderrr/facebook_chat
+  - cloudfiles
   - colombo
   - contacts
   - createsend
-  - croaky/twitter-search
   - disqus_api
   - ebay
   - eztz
@@ -51,7 +50,6 @@ projects:
   - octopi
   - omniauth-cloudsdale
   - quimby
-  - rackspace/ruby-cloudfiles
   - rebay
   - right_flexiscale
   - rjiffy


### PR DESCRIPTION
After adding the download of github data via https://github.com/rubytoolbox/rubytoolbox/pull/59 it turns out these categorized-but-gone-from-github projects are part of the catalog:

```
3scale/acts_as_wiki
bitzesty/mongo_crm
bluescripts/reru_scrum
bluescripts/taskrey
bryanwoods/abingo
centro/tracktor
coderrr/facebook_chat
courtenay/altered_beast
croaky/twitter-search
dmix/weekly_builder
fnando/mail_queue
hansineffect/bats
martinrusev/amonlite
peritor/backdrop
pivotal/guiderails
rackspace/ruby-cloudfiles
sinsiliux/blueprints
willian/has_paginate
yizzreel/jquery_edit_in_place
```

I looked at each one of them. Some were googleable and the owners had renamed their accounts, some are gone for good. Also, some of them are gems by now so could also be moved to their proper gem cousins.