### PR TITLE
Update javascript_tools.yml

### DIFF
--- a/catalog/JavaScript/javascript_tools.yml
+++ b/catalog/JavaScript/javascript_tools.yml
@@ -20,8 +20,10 @@ projects:
   - poke_js
   - rack-jquery
   - rake-minify
+  - react-rails
   - sprockets
   - SrBuj
   - uglifier
   - vendorer
+  - webpacker
   - wiselinks

--- a/catalog/JavaScript/javascript_tools.yml
+++ b/catalog/JavaScript/javascript_tools.yml
@@ -1,5 +1,5 @@
 name: JavaScript Tools
-description: 
+description:
 projects:
   - barista
   - coffee-script
@@ -20,7 +20,6 @@ projects:
   - poke_js
   - rack-jquery
   - rake-minify
-  - react-rails
   - sprockets
   - SrBuj
   - uglifier

--- a/catalog/JavaScript/react_tools.yml
+++ b/catalog/JavaScript/react_tools.yml
@@ -1,0 +1,6 @@
+name: React Tools
+description: Tools for integrating with ReactJS
+projects:
+  - react-rails
+  - react_on_rails
+  - webpacker-react


### PR DESCRIPTION
:art: adding react-rails and webpacker

There is a small cluster of react-based gems. Not sure if they would all go in the Javascript Tools category or have their own.
- https://github.com/reactjs/react-rails (disclaimer: I am currently a maintainer)
- https://github.com/shakacode/react_on_rails and,
- https://github.com/renchap/webpacker-react

Also added https://github.com/rails/webpacker since it's the new alternative to Sprockets which is in this category.