### PR TITLE
Add administrate to the Rails Admin Interfaces category

### DIFF
--- a/catalog/Rails_Plugins/rails_admin_interfaces.yml
+++ b/catalog/Rails_Plugins/rails_admin_interfaces.yml
@@ -7,6 +7,7 @@ projects:
   - admin_assistant
   - admin_data
   - admin_interface
+  - administrate
   - commondream/control_center
   - dry_crud
   - fullstack-admin


### PR DESCRIPTION
Hello! Thank you very much for bringing back the Ruby Toolbox 👏 Used it so much in the past, and been missing it!

As the title describes, this PR aims to add Thoughtbot's administrate engine to the Rails Admin Interfaces category.