### PR TITLE
Add shrine gem to "Rails File Uploads" category

### DIFF
--- a/catalog/Rails_Plugins/rails_file_uploads.yml
+++ b/catalog/Rails_Plugins/rails_file_uploads.yml
@@ -11,5 +11,6 @@ projects:
   - paperclip
   - papermill
   - refile
+  - shrine
   - simple-image-uploader
   - technoweenie/attachment_fu


### PR DESCRIPTION
Shrine is a file upload toolkit for ruby projects, and should probably be included in this category.

Ruby Toolbox Page: https://www.ruby-toolbox.com/projects/shrine
Github Repo: https://github.com/janko-m/shrine