### PR TITLE
Add LiteCable to pub/sub

### DIFF
--- a/catalog/Web_Apps_Services_Interaction/HTTP_Pub_Sub.yml
+++ b/catalog/Web_Apps_Services_Interaction/HTTP_Pub_Sub.yml
@@ -1,6 +1,8 @@
 name: HTTP Pub/Sub
 description: 
 projects:
+  - actioncable
+  - anycable
   - danthes
   - em-websocket
   - faye

--- a/catalog/Web_Apps_Services_Interaction/HTTP_Pub_Sub.yml
+++ b/catalog/Web_Apps_Services_Interaction/HTTP_Pub_Sub.yml
@@ -6,6 +6,7 @@ projects:
   - faye
   - faye-rails
   - libwebsocket
+  - litecable
   - private_pub
   - socky-server
   - websocket


### PR DESCRIPTION
LiteCable is a lightweight ActionCable implementation for non-Rails projects

GitHub: https://github.com/palkan/litecable