### PR TITLE
catalog.rb: Avoiding p as a local name

### DIFF
--- a/lib/catalog.rb
+++ b/lib/catalog.rb
@@ -46,7 +46,7 @@ class Catalog
   end
 
   def categories_at(path)
-    Dir[File.join(path, "*.yml")].reject { |p| File.basename(p) == "_meta.yml" }.map do |category_path|
+    Dir[File.join(path, "*.yml")].reject { |file_path| File.basename(file_path) == "_meta.yml" }.map do |category_path|
       YAML.safe_load(File.read(category_path)).merge(permalink: File.basename(category_path).gsub(".yml", ""))
     end
   end


### PR DESCRIPTION
Hi!

This PR is kind of a readability change: some readers (me) would interpret a `p` as `Kernel#p` in Ruby code. To avoid this, this PR renames a block-local variable to a longer name.