### PR TITLE
scout_plugins => scout_apm

### DIFF
--- a/catalog/Maintenance_Monitoring/rails_instrumentation.yml
+++ b/catalog/Maintenance_Monitoring/rails_instrumentation.yml
@@ -23,6 +23,6 @@ projects:
   - rails_instrument
   - rails_metrics
   - rails_view_annotator
-  - scoutapp/scout-plugins
+  - scout_apm
   - slowgrowl
   - system-metrics


### PR DESCRIPTION
The `scout_plugins` repo doesn't have Ruby app instrumentation plugins - it's more service-focused (monitoring Postgres, Redis, etc). `scout_apm` is a dedicated app instrumentation gem.