### PR TITLE
Master - Adds fast_jsonapi to API_Builders

### DIFF
--- a/catalog/Web_Apps_Services_Interaction/API_Builders.yml
+++ b/catalog/Web_Apps_Services_Interaction/API_Builders.yml
@@ -1,11 +1,12 @@
 name: API Builders
-description: 
+description:
 projects:
   - active_model_serializers
   - acts_as_api
   - api-versions
   - apiary
   - bldr
+  - fast_jsonapi
   - grape
   - jbuilder
   - rabl


### PR DESCRIPTION
Adds the [fast_jsonapi](https://rubygems.org/gems/fast_jsonapi) gem to API_Builders.
I'm very happy to see this project revived!!!  KUDOS  :tada: