### PR TITLE
Fix name for fir, the irb replacement

### DIFF
--- a/catalog/Developer_Tools/irb_Alternatives.yml
+++ b/catalog/Developer_Tools/irb_Alternatives.yml
@@ -1,7 +1,7 @@
 name: irb Alternatives
 description: 
 projects:
-  - fir
+  - fir-repl
   - pry
   - rib
   - ripl


### PR DESCRIPTION
fir-repl is the official name on Rubygems

Sorry about this :(