### PR TITLE
Adding Formular gem to Form Builders

### DIFF
--- a/catalog/HTML_Markup/rails_form_builders.yml
+++ b/catalog/HTML_Markup/rails_form_builders.yml
@@ -1,5 +1,5 @@
 name: Form Builders
-description: 
+description:
 projects:
   - airblade/air_budd_form_builder
   - bootstrap_form
@@ -9,8 +9,10 @@ projects:
   - formize
   - formtastic
   - formula
+  - formular
   - mongoid_form
   - nested_form
   - parsley_simple_form
   - simple_form
   - twitter_bootstrap_form_for
+


### PR DESCRIPTION
Formular is a framework and ORM agnostic form builder with an API similar to SimpleForm. It is part of Trailblazer ecosystem but can be used stand-alone, and with any Ruby framework. 