### PR TITLE
Adding comfy_bootstrap_form

### DIFF
--- a/catalog/HTML_Markup/rails_form_builders.yml
+++ b/catalog/HTML_Markup/rails_form_builders.yml
@@ -6,6 +6,7 @@ projects:
   - bootstrap_forms
   - campo
   - cocoon
+  - comfy_bootstrap_form
   - formize
   - formtastic
   - formula


### PR DESCRIPTION
Extension to `ActionView::Helpers::FormBuilder` that wraps form fields in Bootstrap 4 markup.