### PR TITLE
Add alphabetical order requirement to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Each `category.yml` currently contains:
 
 * `name` (string, required): Human display name of the category name
 * `description` (string, optional): A (markdown-formatted) category description
-* `projects` (array of strings, required): The list of projects to list in
+* `projects` (array of strings in alphabetical order, required): The list of projects to list in
   that category. For rubygems, this is the plain gem name, for github repos it's
   the full repo slug (`github_user/repo_name`). Projects can be listed in multiple
   categories.


### PR DESCRIPTION
This is a commonly made error, and the requirement doesn't seem to be explicitly stated.