### PR TITLE
Add Flammarion to GUI toolkits

### DIFF
--- a/catalog/Developer_Tools/GUI_Frameworks.yml
+++ b/catalog/Developer_Tools/GUI_Frameworks.yml
@@ -2,6 +2,7 @@ name: GUI Frameworks
 description: 
 projects:
   - ffi-tk
+  - flammarion
   - fxruby
   - gtk2
   - monkeybars


### PR DESCRIPTION
Flammarion is a nifty GUI toolkit created for use in an interactive ruby environment or for quickly prototyping a GUI for scripts.