### PR TITLE
Add Juwelier to Gem Creation category

### DIFF
--- a/catalog/Developer_Tools/gem_creation.yml
+++ b/catalog/Developer_Tools/gem_creation.yml
@@ -10,6 +10,7 @@ projects:
   - hoe
   - inochi
   - jeweler
+  - juwelier
   - newgem
   - ore
   - rag


### PR DESCRIPTION
https://github.com/technicalpickles/jeweler is maintenance mode and original author suggests people use Juwelier for new projects. 

Source: https://github.com/technicalpickles/jeweler#jeweler-craft-the-perfect-rubygem