### PR TITLE
markdown_helper

### DIFF
--- a/catalog/HTML_Markup/markup_processors.yml
+++ b/catalog/HTML_Markup/markup_processors.yml
@@ -17,3 +17,4 @@ projects:
   - smiley
   - stupid_formatter
   - vkhater-redcarpet
+  - markdown_helper


### PR DESCRIPTION
Gem [markdown_helper](https://rubygems.org/gems/markdown_helper} supports:

* File inclusion: to include text from other files, as code-block or markdown.
* Image path resolution: to resolve relative image paths to absolute URL paths (so they work even in gem documentation).
* Image attributes: image attributes are passed through to an HTML img tag.

Thanks for contributing to the Ruby Toolbox catalog! <3

Before submitting your pull request:

* If you are submitting a github-based project, please verify the project is not packaged as a rubygem
* Please make sure the projects are listed in alphabetical order
* Make sure the CI build passes, we validate your proposed changes in the test suite :)
