### PR TITLE
Please add the Plezi framework

### DIFF
--- a/catalog/Web_Apps_Services_Interaction/web_app_frameworks.yml
+++ b/catalog/Web_Apps_Services_Interaction/web_app_frameworks.yml
@@ -15,6 +15,7 @@ projects:
   - merb-core
   - padrino
   - pakyow
+  - plezi
   - rack
   - rails
   - ramaze


### PR DESCRIPTION
The Plezi framework leverages the iodine Ruby server for Websocket, Pub/Sub oriented apps.