### PR TITLE
Please add the iodine HTTP/Websocket server

### DIFF
--- a/catalog/Web_Apps_Services_Interaction/HTTP_Pub_Sub.yml
+++ b/catalog/Web_Apps_Services_Interaction/HTTP_Pub_Sub.yml
@@ -7,6 +7,7 @@ projects:
   - em-websocket
   - faye
   - faye-rails
+  - iodine
   - libwebsocket
   - litecable
   - private_pub


### PR DESCRIPTION
The iodine HTTP/Websocket server (a Ruby C extension) includes native pub/sub as well as a Redis engine / adapter for easy horizontal scaling.

Please consider adding iodine to the catalog.

Thanks.