### PR TITLE
Update Active_Record_Named_Scopes.yml

### DIFF
--- a/catalog/Active_Record_Plugins/Active_Record_Named_Scopes.yml
+++ b/catalog/Active_Record_Plugins/Active_Record_Named_Scopes.yml
@@ -11,5 +11,6 @@ projects:
   - searchlogic
   - sexy_scopes
   - technoweenie/can_search
+  - trailblazer-finder
   - trixy_scopes
   - utility_scopes


### PR DESCRIPTION
Adding trailblazer-finder is a Finder Object, that is part of Trailblazer framework. But it is designed to be used on its own as a separate gem.  It was influenced by popular Ransack gem, but in addition to active-record, it can be used with DataMapper or Sequel. It also integrates with Kaminari or Will Paginate, as well as FriendlyId

Thanks for contributing to the Ruby Toolbox catalog! <3

Before submitting your pull request:

* If you are submitting a github-based project, please verify the project is not packaged as a rubygem
* Please make sure the projects are listed in alphabetical order
* Make sure the CI build passes, we validate your proposed changes in the test suite :)
