### PR TITLE
Please add the iodine web server

### DIFF
--- a/catalog/Provision_Deploy_Host/web_servers.yml
+++ b/catalog/Provision_Deploy_Host/web_servers.yml
@@ -4,6 +4,7 @@ projects:
   - agoo
   - ebb
   - hoof
+  - iodine
   - mongrel
   - mongrel2
   - passenger


### PR DESCRIPTION
The iodine HTTP/Websocket server (a Ruby C extension) supports, multi-threading, cluster mode and hybrid deployment (multi-threaded workers in cluster mode).

( This is in continuation of PR #101 )

Thanks!