### PR TITLE
Promote the category "API Clients"

### DIFF
--- a/catalog/HTTP_API_Clients/_meta.yml
+++ b/catalog/HTTP_API_Clients/_meta.yml
@@ -1,0 +1,1 @@
+name: HTTP API Clients

--- a/catalog/HTTP_API_Clients/api_clients.yml
+++ b/catalog/HTTP_API_Clients/api_clients.yml
@@ -1,4 +1,4 @@
-name: API Clients
+name: Other Clients
 description:
 projects:
   - amazon-ecs


### PR DESCRIPTION
Closes rubytoolbox/rubytoolbox#131.