### PR TITLE
Bundle update parser

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,7 +50,7 @@ GEM
       childprocess (~> 0.6, >= 0.6.3)
       iniparse (~> 1.4)
     parallel (1.12.1)
-    parser (2.5.0.4)
+    parser (2.5.0.5)
       ast (~> 2.4.0)
     powerpack (0.1.1)
     pry (0.11.3)


### PR DESCRIPTION
Master branch now holds a deleted version of `parser` gem: 
```
Fetching gem metadata from https://rubygems.org/..........
Your bundle is locked to parser (2.5.0.4), but that version could not be found in any of the sources listed in your
Gemfile. If you haven't changed sources, that means the author of parser (2.5.0.4) has removed it. You'll need to
update your bundle to a different version of parser (2.5.0.4) that hasn't been removed in order to install.
```