### PR TITLE
rails_indexes was deprecated in favor of lol_dba

### DIFF
--- a/catalog/Active_Record_Plugins/Active_Record_Index_Assistants.yml
+++ b/catalog/Active_Record_Plugins/Active_Record_Index_Assistants.yml
@@ -2,7 +2,6 @@ name: Active Record Index Assistants
 description: 
 projects:
   - automatic_foreign_key
-  - eladmeidar/rails_indexes
   - foreigner
   - immigrant
   - lol_dba


### PR DESCRIPTION
As stated in [their README](https://github.com/eladmeidar/rails_indexes).