### PR TITLE
Adding pagy to proper catalog

### DIFF
--- a/catalog/Active_Record_Plugins/pagination.yml
+++ b/catalog/Active_Record_Plugins/pagination.yml
@@ -5,6 +5,8 @@ projects:
   - kaminari
   - kaminari-bootstrap
   - paged_scopes
+  - pagy
+  - pagy-extras
   - simply_paginate
   - sorted
   - will_paginate


### PR DESCRIPTION
This pull request properly catalogs `pagy` and `pagy-extras` gems.