### PR TITLE
Add pastel to Terminal Coloring category

### DIFF
--- a/catalog/Developer_Tools/Terminal_Coloring.yml
+++ b/catalog/Developer_Tools/Terminal_Coloring.yml
@@ -6,5 +6,6 @@ projects:
   - colorize
   - lolcat
   - paint
+  - pastel
   - rainbow
   - term-ansicolor


### PR DESCRIPTION
Add [pastel](https://github.com/piotrmurach/pastel) to terminal coloring gems.

Thanks for contributing to the Ruby Toolbox catalog! <3

**Before submitting your pull request:**

- [x] If you are submitting a github-based project, please verify the project is not packaged as a rubygem
- [x] Please make sure the projects are listed in alphabetical order
- [x] Make sure the CI build passes, we validate your proposed changes in the test suite :)
