### PR TITLE
Add tty-progressbar to CLI Progress Bars category

### DIFF
--- a/catalog/Developer_Tools/CLI_Progress_Bars.yml
+++ b/catalog/Developer_Tools/CLI_Progress_Bars.yml
@@ -11,3 +11,4 @@ projects:
   - ruby-progressbar
   - shell-spinner
   - spinning_cursor
+  - tty-progressbar


### PR DESCRIPTION
Add [tty-progressbar](https://github.com/piotrmurach/tty-progressbar) to CLI progress bars category.

Thanks for contributing to the Ruby Toolbox catalog! <3

**Before submitting your pull request:**

- [x] If you are submitting a github-based project, please verify the project is not packaged as a rubygem
- [x] Please make sure the projects are listed in alphabetical order
- [x] Make sure the CI build passes, we validate your proposed changes in the test suite :)
