### PR TITLE
Add tty-config to Configuration Management category

### DIFF
--- a/catalog/Developer_Tools/Configuration_Management.yml
+++ b/catalog/Developer_Tools/Configuration_Management.yml
@@ -40,5 +40,6 @@ projects:
   - settingslogic
   - simpleconfig
   - store_configurable
+  - tty-config
   - user_config
   - yettings


### PR DESCRIPTION
Add [tty-config](https://github.com/piotrmurach/tty-config) to Configuration Management category

Thanks for contributing to the Ruby Toolbox catalog! <3

**Before submitting your pull request:**

- [x] If you are submitting a github-based project, please verify the project is not packaged as a rubygem
- [x] Please make sure the projects are listed in alphabetical order
- [x] Make sure the CI build passes, we validate your proposed changes in the test suite :)
