### PR TITLE
Fix some rubocop offenses, actually run it on CI (－‸ლ)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,8 @@ require: rubocop-rspec
 AllCops:
   Exclude:
     - 'tmp/**/*.rb'
+    # See https://qiita.com/ozhaan/items/40ea864757162e931be1
+    - 'vendor/**/*'
 
 Metrics/BlockLength:
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -42,6 +42,12 @@ Style/DoubleNegation:
 Style/StringLiterals:
   EnforcedStyle: double_quotes
 
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
   EnforcedStyleForMultiline: comma
 
+Style/TrailingCommaInHashLiteral:
+  EnforcedStyleForMultiline: comma
+
+# I actually use this a lot with `private :foo=`
+Style/AccessModifierDeclarations:
+  Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 script:
   - bundle exec rspec
+  - bundle exec rubocop
   - bundle exec rake export
 deploy:
   # See https://github.com/travis-ci/travis-ci/issues/9312


### PR DESCRIPTION
I noticed while working on the tests that there were a few minor rubocop offenses and config incompatibilites on the repo, coming from recent rubocop upgrades (i.e. #163) that were not caught by CI - turns out rubocop was not running on CI :man_facepalming: 

This fixes that problem 