### PR TITLE
Update Gem Creation Category - Adding quik gem (Gem / Project Quick Start Scaffolder)

### DIFF
--- a/catalog/Developer_Tools/gem_creation.yml
+++ b/catalog/Developer_Tools/gem_creation.yml
@@ -13,6 +13,7 @@ projects:
   - juwelier
   - newgem
   - ore
+  - quik
   - rag
   - rookie
   - rubygems-tasks


### PR DESCRIPTION
Thanks for contributing to the Ruby Toolbox catalog! <3

**Before submitting your pull request:**

- [x] If you are submitting a github-based project, please verify the project is not packaged as a rubygem
- [x] Please make sure the projects are listed in alphabetical order
- [x] Make sure the CI build passes, we validate your proposed changes in the test suite :)

Again thanks for the great catalog. Would be great to see the quik gem and tool added to Gem Creation category.

Keep it up. Cheers. Prost.