### PR TITLE
Add multi_daemons gem in correct order

### DIFF
--- a/catalog/Background_Processing/daemonizing.yml
+++ b/catalog/Background_Processing/daemonizing.yml
@@ -10,6 +10,7 @@ projects:
   - fallen
   - foreverb
   - looper
+  - multi_daemons
   - robustthread
   - simple-daemon
   - titan


### PR DESCRIPTION
Fixes order on #186, because I cannot push to fork branches. We should find a better way for this kind of stuff...