### PR TITLE
Split coverage into it's own category from metrics

### DIFF
--- a/catalog/Code_Quality/code_coverage.yml
+++ b/catalog/Code_Quality/code_coverage.yml
@@ -1,0 +1,12 @@
+name: Code Coverage
+description:
+  Utilities that report which code is being run. Most commonly this is used
+  as test coverage which reports what parts of your code are not tested, but there
+  are also tools to find dead production code
+projects:
+  - cover_me
+  - coveralls
+  - coverband
+  - rcov
+  - simplecov
+  - single_cov

--- a/catalog/Code_Quality/code_metrics.yml
+++ b/catalog/Code_Quality/code_metrics.yml
@@ -1,12 +1,13 @@
 name: Code Metrics
 description:
+    Utilities to improve code quality by reporting common code
+    smells like complexity, unsafe defaults, unused variables or stylistic
+    inconsistencies
 projects:
   - cane
   - coco
   - code_statistics
   - code_stats2
-  - cover_me
-  - coveralls
   - flay
   - flog
   - foodcritic
@@ -17,8 +18,6 @@ projects:
   - outlaw
   - pelusa
   - rails_best_practices
-  - rcov
-  - rcov_plugin
   - reek
   - roodi
   - rubocop
@@ -26,6 +25,5 @@ projects:
   - rubycritic
   - Saikuro
   - sandi_meter
-  - simplecov
   - tailor
   - thoughtbot/report_card


### PR DESCRIPTION
This PR splits coverage tools into it's own category separate from Code Metrics. It also adds descriptions for the categories.

Reasons:

* There is a bunch of different code coverage tools with varying purposes (i.e. coverband for finding dead code in production). This PR also expands the coverage tools by adding coverband and single_cov
* The purpose of the tools is similar, but different. If you use rubocop, you might as well use simplecov. This is not so much the case for other categories like web or testing frameworks.
* The code quality category group so far had only this one "metrics" category, making it a somewhat useless "group"

Disclosure: I am the author of simplecov, but this PR is not intended to sneak in a new category of tools just to put simplecov on top of some category, on the contrary I hope this will give the alternatives more visibility