### PR TITLE
Add yard-doctest to the list of testing frameworks

### DIFF
--- a/catalog/Testing/testing_frameworks.yml
+++ b/catalog/Testing/testing_frameworks.yml
@@ -19,3 +19,4 @@ projects:
   - testrocket
   - testy
   - wrong
+  - yard-doctest


### PR DESCRIPTION
I'm the author of the gem which was created as some sort of replacement for rubydoctest: https://github.com/p0deje/yard-doctest.

**Before submitting your pull request:**

- [x] If you are submitting a github-based project, please verify the project is not packaged as a rubygem
- [x] Please make sure the projects are listed in alphabetical order
- [x] Make sure the CI build passes, we validate your proposed changes in the test suite :)