### PR TITLE
Added Git Cop gem.

### DIFF
--- a/catalog/Code_Quality/code_metrics.yml
+++ b/catalog/Code_Quality/code_metrics.yml
@@ -11,6 +11,7 @@ projects:
   - flay
   - flog
   - foodcritic
+  - git-cop
   - jslint_on_rails
   - kevinrutherford/crap4r
   - metric_abc

--- a/catalog/Developer_Tools/git_Tools.yml
+++ b/catalog/Developer_Tools/git_Tools.yml
@@ -1,9 +1,10 @@
 name: git Tools
-description: 
+description:
 projects:
   - ezgit
   - gas
   - git
+  - git-cop
   - githug
   - gitolite
   - gitsu


### PR DESCRIPTION
## Overview

Enforces consistent Git commits.

- Enforces a [Git Rebase Workflow](https://is.gd/6cgc1J).
- Enforces a clean and consistent Git commit history.
- Provides Continuous Integration (CI) build server support.
- Provides Git Hook support for local use.
- Provides a customizable suite of style cops.

There is a lot this linter can do in terms of local feedback as well as
part of your continuous integration builds. To learn more, check out
the project [README](https://github.com/bkuhlmann/git-cop) for details.

## Checklist

- [x] If you are submitting a github-based project, please verify the project is not packaged as a rubygem
- [x] Please make sure the projects are listed in alphabetical order
- [x] Make sure the CI build passes, we validate your proposed changes in the test suite :)
