### PR TITLE
Add Simple Scheduler gem

### DIFF
--- a/catalog/Background_Processing/scheduling.yml
+++ b/catalog/Background_Processing/scheduling.yml
@@ -8,5 +8,6 @@ projects:
   - rufus-scheduler
   - sidecloq
   - sidekiq-cron
+  - simple_scheduler
   - Swirrl/Taskit
   - whenever


### PR DESCRIPTION
Simple Scheduler is a scheduling add-on that is designed to be used with
[Sidekiq](http://sidekiq.org) and [Heroku Scheduler](https://elements.heroku.com/addons/scheduler). It gives you the ability to **schedule tasks at any interval** without adding
a clock process. Heroku Scheduler only allows you to schedule tasks every 10 minutes,
every hour, or every day. It's very clean, stable, and easy to use.