### PR TITLE
add que

### DIFF
--- a/catalog/Background_Processing/Background_Jobs.yml
+++ b/catalog/Background_Processing/Background_Jobs.yml
@@ -22,6 +22,7 @@ projects:
   - navvy
   - ncr/background-fu
   - qu
+  - que
   - quebert
   - queue_classic
   - rabbit_jobs


### PR DESCRIPTION
Adds [Que](https://github.com/chanks/que/). A background processing library that uses PostgreSQL's advisory locks for speed and reliability.