### PR TITLE
Add description for gem creation category, include bundler

### DIFF
--- a/catalog/Developer_Tools/gem_creation.yml
+++ b/catalog/Developer_Tools/gem_creation.yml
@@ -1,7 +1,8 @@
 name: Gem Creation
-description:
+description: Tools that aid in creating, maintaining and publishing Rubygems
 projects:
   - bones
+  - bundler
   - echoe
   - enginex
   - gem-newgem


### PR DESCRIPTION
This adds a description for the gem creation category, and also includes bundler in the list.

I was slightly torn about including bundler since due to it's ubiquity it's a clear popularity leader in this group, yet the main source of it's popularity stems from it's dependency management feature, not creating gems. Ultimately though it's a very popular choice for scaffolding gems as well, so I think it absolutely must be on this list here as well.