### PR TITLE
Add authz to rails_authorization.yml

### DIFF
--- a/catalog/Security/rails_authorization.yml
+++ b/catalog/Security/rails_authorization.yml
@@ -10,6 +10,7 @@ projects:
   - aegis
   - allowy
   - authority
+  - authz
   - baldwindavid/padlock_authorization
   - canable
   - canard


### PR DESCRIPTION
Add the authz gem located at https://github.com/serodriguez68/authz to the catalogue.

Authz is an opinionated almost-turnkey solution for managing authorization in your Rails application.

**Authz provides you with:**
- An authorization admin interface that allows non-developers to configure and manage how authorization works for your app. The admin makes it very easy to answer questions like "who can create top-secret reports"? or "what can John Doe do?"
- An opinionated approach on how to structure your permissions that promotes clarity and maintainability.
- An easy-to-use API that allows developers to integrate Authz into their apps with very little code while providing them with the tools they need.

**Before submitting your pull request:**

* [x]  If you are submitting a github-based project, please verify the project is not packaged as a rubygem
* [x]  Please make sure the projects are listed in alphabetical order
* [x]  Make sure the CI build passes, we validate your proposed changes in the test suite :)