### PR TITLE
Add wifiwand project (https://github.com/keithrbennett/wifiwand).

### DIFF
--- a/catalog/Networking/networking_tools.yml
+++ b/catalog/Networking/networking_tools.yml
@@ -4,4 +4,4 @@ projects:
   - ipaddress
   - macker
   - maxminddb
-  - wifi_wand
+  - wifi-wand

--- a/catalog/Networking/networking_tools.yml
+++ b/catalog/Networking/networking_tools.yml
@@ -4,3 +4,4 @@ projects:
   - ipaddress
   - macker
   - maxminddb
+  - wifiwand

--- a/catalog/Networking/networking_tools.yml
+++ b/catalog/Networking/networking_tools.yml
@@ -4,4 +4,4 @@ projects:
   - ipaddress
   - macker
   - maxminddb
-  - wifiwand
+  - wifi_wand


### PR DESCRIPTION
I don't understand what you mean by "If you are submitting a github-based project, please verify the project is not packaged as a rubygem". `wifi_wand` _is_ also a gem. Is there a different way to submit it for the catalog?