### PR TITLE
Add AppSignal to app instrumentation category

### DIFF
--- a/catalog/Maintenance_Monitoring/rails_instrumentation.yml
+++ b/catalog/Maintenance_Monitoring/rails_instrumentation.yml
@@ -1,6 +1,7 @@
 name: App Instrumentation
 description:
 projects:
+  - appsignal
   - better_errors
   - bullet
   - dashing


### PR DESCRIPTION
Add AppSignal (https://appsignal.com/) to the app instrumentation category.

https://www.ruby-toolbox.com/projects/appsignal

**Before submitting your pull request:**

- [x] ~If you are submitting a github-based project, please verify the project is not packaged as a rubygem~
- [x] Please make sure the projects are listed in alphabetical order
- [x] Make sure the CI build passes, we validate your proposed changes in the test suite :)
