### PR TITLE
Update Service_Objects.yml

### DIFF
--- a/catalog/Code_Organization/Service_Objects.yml
+++ b/catalog/Code_Organization/Service_Objects.yml
@@ -1,8 +1,7 @@
 name: Service Objects
-description:
+description: Libraries to isolate application domain logic into separate classes.
 projects:
   - active_interaction
-  - decent_exposure
   - dry-transaction
   - interactor
   - mutations


### PR DESCRIPTION
Add description for Service Objects category.
Also `decent_exposure` is not a service object gem but a library to set up a cleaner interface between a Rails controller and its views.

Thanks for contributing to the Ruby Toolbox catalog! <3

**Before submitting your pull request:**

- [x] If you are submitting a github-based project, please verify the project is not packaged as a rubygem
- [x] Please make sure the projects are listed in alphabetical order
- [x] Make sure the CI build passes, we validate your proposed changes in the test suite :)
