### PR TITLE
Add capybara-chrome

### DIFF
--- a/catalog/Testing/browser_testing.yml
+++ b/catalog/Testing/browser_testing.yml
@@ -3,6 +3,7 @@ description: Write and run automated tests of your web app in a real-world brows
 projects:
   - akephalos
   - capybara
+  - capybara-chrome
   - capybara-webkit
   - celerity
   - culerity


### PR DESCRIPTION
A headless capybara driver using the Chrome browser.

Thanks for contributing to the Ruby Toolbox catalog! <3

**Before submitting your pull request:**

- [ ] If you are submitting a github-based project, please verify the project is not packaged as a rubygem
- [ ] Please make sure the projects are listed in alphabetical order
- [ ] Make sure the CI build passes, we validate your proposed changes in the test suite :)
