### PR TITLE
Add hanami-mailer to E-Mail Delivery

### DIFF
--- a/catalog/Communication/e_mail.yml
+++ b/catalog/Communication/e_mail.yml
@@ -3,6 +3,7 @@ description: Easily send e-mails from your Ruby programs
 projects:
   - actionmailer
   - capistrano_mailer
+  - hanami-mailer
   - mail
   - mailit
   - pony


### PR DESCRIPTION
[hanami-mailer](https://github.com/hanami/mailer) is a nice generic alternative to ActionMailer.