### PR TITLE
Clean up the "Rails Search" category

### DIFF
--- a/catalog/Active_Record_Plugins/rails_search.yml
+++ b/catalog/Active_Record_Plugins/rails_search.yml
@@ -11,7 +11,6 @@ projects:
   - scoped_search
   - searchkick
   - searchlight
-  - slingshot-rb
   - sunspot
   - sunspot_rails
   - thinking-sphinx

--- a/catalog/Active_Record_Plugins/rails_search.yml
+++ b/catalog/Active_Record_Plugins/rails_search.yml
@@ -18,7 +18,6 @@ projects:
   - solr_query
   - sunspot
   - sunspot_rails
-  - texticle
   - thinking-sphinx
   - tire
   - xapian_db

--- a/catalog/Active_Record_Plugins/rails_search.yml
+++ b/catalog/Active_Record_Plugins/rails_search.yml
@@ -1,7 +1,6 @@
 name: Rails Search
 description: 
 projects:
-  - acts_as_ferret
   - acts_as_fulltextable
   - acts_as_solr
   - acts_as_solr_reloaded

--- a/catalog/Active_Record_Plugins/rails_search.yml
+++ b/catalog/Active_Record_Plugins/rails_search.yml
@@ -3,7 +3,6 @@ description:
 projects:
   - acts_as_ferret
   - acts_as_fulltextable
-  - acts_as_indexed
   - acts_as_solr
   - acts_as_solr_reloaded
   - chewy

--- a/catalog/Active_Record_Plugins/rails_search.yml
+++ b/catalog/Active_Record_Plugins/rails_search.yml
@@ -4,7 +4,6 @@ projects:
   - acts_as_fulltextable
   - acts_as_solr
   - chewy
-  - delsolr
   - elasticsearch
   - elasticsearch-rails
   - elastictastic

--- a/catalog/Active_Record_Plugins/rails_search.yml
+++ b/catalog/Active_Record_Plugins/rails_search.yml
@@ -3,7 +3,6 @@ description:
 projects:
   - acts_as_fulltextable
   - acts_as_solr
-  - acts_as_solr_reloaded
   - chewy
   - delsolr
   - elasticsearch

--- a/catalog/Active_Record_Plugins/rails_search.yml
+++ b/catalog/Active_Record_Plugins/rails_search.yml
@@ -1,7 +1,6 @@
 name: Rails Search
 description: 
 projects:
-  - acts_as_fulltextable
   - chewy
   - elasticsearch
   - elasticsearch-rails

--- a/catalog/Active_Record_Plugins/rails_search.yml
+++ b/catalog/Active_Record_Plugins/rails_search.yml
@@ -5,7 +5,6 @@ projects:
   - chewy
   - elasticsearch
   - elasticsearch-rails
-  - elastictastic
   - ferret
   - pg_search
   - rsolr

--- a/catalog/Active_Record_Plugins/rails_search.yml
+++ b/catalog/Active_Record_Plugins/rails_search.yml
@@ -3,7 +3,6 @@ description:
 projects:
   - chewy
   - elasticsearch
-  - elasticsearch-rails
   - ferret
   - pg_search
   - rsolr
@@ -12,7 +11,6 @@ projects:
   - searchkick
   - searchlight
   - sunspot
-  - sunspot_rails
   - thinking-sphinx
   - tire
   - xapian_db

--- a/catalog/Active_Record_Plugins/rails_search.yml
+++ b/catalog/Active_Record_Plugins/rails_search.yml
@@ -23,4 +23,3 @@ projects:
   - thinking-sphinx
   - tire
   - xapian_db
-  - xapit

--- a/catalog/Active_Record_Plugins/rails_search.yml
+++ b/catalog/Active_Record_Plugins/rails_search.yml
@@ -2,7 +2,6 @@ name: Rails Search
 description: 
 projects:
   - acts_as_fulltextable
-  - acts_as_solr
   - chewy
   - elasticsearch
   - elasticsearch-rails

--- a/catalog/Active_Record_Plugins/rails_search.yml
+++ b/catalog/Active_Record_Plugins/rails_search.yml
@@ -13,7 +13,6 @@ projects:
   - searchkick
   - searchlight
   - slingshot-rb
-  - solr_query
   - sunspot
   - sunspot_rails
   - thinking-sphinx

--- a/catalog/Active_Record_Plugins/rails_search.yml
+++ b/catalog/Active_Record_Plugins/rails_search.yml
@@ -23,7 +23,6 @@ projects:
   - solr_query
   - sunspot
   - sunspot_rails
-  - sunspot_solr
   - texticle
   - thinking-sphinx
   - tire

--- a/catalog/Active_Record_Plugins/rails_search.yml
+++ b/catalog/Active_Record_Plugins/rails_search.yml
@@ -13,7 +13,6 @@ projects:
   - elastictastic
   - ferret
   - pg_search
-  - redis-search
   - rsolr
   - ruby_simple_search
   - scoped_search


### PR DESCRIPTION
There were many outdated and unmaintained gems in the "Rails Search" category, so I removed them to keep the list more focused. I included the rationale for removal in each respective commit message.

I also removed the `elasticsearch-rails` and `sunspot_rails` extensions, because I considered them to be redundant given that `elasticsearch` and `sunspot` gems are already on the list and their READMEs mention the existence of their respective Rails extensions.