### PR TITLE
Clean up the "Code Coverage" section

### DIFF
--- a/catalog/Code_Quality/code_coverage.yml
+++ b/catalog/Code_Quality/code_coverage.yml
@@ -7,7 +7,6 @@ projects:
   - cover_me
   - coveralls
   - coverband
-  - rcov
   - simplecov
   - single_cov
   - undercover

--- a/catalog/Code_Quality/code_coverage.yml
+++ b/catalog/Code_Quality/code_coverage.yml
@@ -4,7 +4,6 @@ description:
   as test coverage which reports what parts of your code are not tested, but there
   are also tools to find dead production code
 projects:
-  - cover_me
   - coveralls
   - coverband
   - simplecov

--- a/catalog/Code_Quality/code_coverage.yml
+++ b/catalog/Code_Quality/code_coverage.yml
@@ -6,6 +6,7 @@ description:
 projects:
   - coveralls
   - coverband
+  - covered
   - simplecov
   - single_cov
   - undercover


### PR DESCRIPTION
Removes outdated `rcov` and `cover_me`, and adds `covered` to "Code Coverage" category.