### PR TITLE
Clean up the "Background Jobs" section

### DIFF
--- a/catalog/Background_Processing/Background_Jobs.yml
+++ b/catalog/Background_Processing/Background_Jobs.yml
@@ -3,7 +3,6 @@ description: Process slow tasks asynchronously to keep response times low, impro
 projects:
   - acts_as_executor
   - backburner
-  - backgrounded
   - barttenbrinke/worker_queue
   - beetle
   - bj

--- a/catalog/Background_Processing/Background_Jobs.yml
+++ b/catalog/Background_Processing/Background_Jobs.yml
@@ -17,7 +17,6 @@ projects:
   - queue_classic
   - rabbit_jobs
   - resque
-  - rock-queue
   - rocketjob
   - runner
   - shoryuken

--- a/catalog/Background_Processing/Background_Jobs.yml
+++ b/catalog/Background_Processing/Background_Jobs.yml
@@ -9,7 +9,6 @@ projects:
   - delayed_job
   - frenzy_bunnies
   - job_reactor
-  - later
   - que
   - quebert
   - queue_classic

--- a/catalog/Background_Processing/Background_Jobs.yml
+++ b/catalog/Background_Processing/Background_Jobs.yml
@@ -17,7 +17,6 @@ projects:
   - later
   - navvy
   - ncr/background-fu
-  - qu
   - que
   - quebert
   - queue_classic

--- a/catalog/Background_Processing/Background_Jobs.yml
+++ b/catalog/Background_Processing/Background_Jobs.yml
@@ -14,7 +14,6 @@ projects:
   - jnstq/job_fu
   - job_reactor
   - later
-  - ncr/background-fu
   - que
   - quebert
   - queue_classic

--- a/catalog/Background_Processing/Background_Jobs.yml
+++ b/catalog/Background_Processing/Background_Jobs.yml
@@ -8,7 +8,6 @@ projects:
   - cloud-crowd
   - delayed_job
   - frenzy_bunnies
-  - job_reactor
   - que
   - quebert
   - queue_classic

--- a/catalog/Background_Processing/Background_Jobs.yml
+++ b/catalog/Background_Processing/Background_Jobs.yml
@@ -12,7 +12,6 @@ projects:
   - queue_classic
   - resque
   - rocketjob
-  - runner
   - shoryuken
   - sidekiq
   - sucker_punch

--- a/catalog/Background_Processing/Background_Jobs.yml
+++ b/catalog/Background_Processing/Background_Jobs.yml
@@ -10,7 +10,6 @@ projects:
   - cloud-crowd
   - delayed_job
   - frenzy_bunnies
-  - jnstq/job_fu
   - job_reactor
   - later
   - que

--- a/catalog/Background_Processing/Background_Jobs.yml
+++ b/catalog/Background_Processing/Background_Jobs.yml
@@ -2,7 +2,6 @@ name: Background Jobs
 description: Process slow tasks asynchronously to keep response times low, improve fault-tolerance and aid with horizontal scaling
 projects:
   - backburner
-  - barttenbrinke/worker_queue
   - beetle
   - bunny
   - cloud-crowd

--- a/catalog/Background_Processing/Background_Jobs.yml
+++ b/catalog/Background_Processing/Background_Jobs.yml
@@ -5,7 +5,6 @@ projects:
   - backburner
   - barttenbrinke/worker_queue
   - beetle
-  - bj
   - bunny
   - cloud-crowd
   - delayed_job

--- a/catalog/Background_Processing/Background_Jobs.yml
+++ b/catalog/Background_Processing/Background_Jobs.yml
@@ -26,6 +26,5 @@ projects:
   - seanohalpin/smqueue
   - shoryuken
   - sidekiq
-  - stalker
   - sucker_punch
   - workling

--- a/catalog/Background_Processing/Background_Jobs.yml
+++ b/catalog/Background_Processing/Background_Jobs.yml
@@ -30,6 +30,5 @@ projects:
   - shoryuken
   - sidekiq
   - stalker
-  - starling
   - sucker_punch
   - workling

--- a/catalog/Background_Processing/Background_Jobs.yml
+++ b/catalog/Background_Processing/Background_Jobs.yml
@@ -11,7 +11,6 @@ projects:
   - cloud-crowd
   - delayed_job
   - frenzy_bunnies
-  - girl_friday
   - gnufied/backgroundrb
   - jnstq/job_fu
   - job_reactor

--- a/catalog/Background_Processing/Background_Jobs.yml
+++ b/catalog/Background_Processing/Background_Jobs.yml
@@ -17,7 +17,6 @@ projects:
   - gnufied/backgroundrb
   - jnstq/job_fu
   - job_reactor
-  - kr/beanstalkd
   - later
   - navvy
   - ncr/background-fu

--- a/catalog/Background_Processing/Background_Jobs.yml
+++ b/catalog/Background_Processing/Background_Jobs.yml
@@ -2,7 +2,6 @@ name: Background Jobs
 description: Process slow tasks asynchronously to keep response times low, improve fault-tolerance and aid with horizontal scaling
 projects:
   - acts_as_executor
-  - amqp
   - backburner
   - backgrounded
   - barttenbrinke/worker_queue

--- a/catalog/Background_Processing/Background_Jobs.yml
+++ b/catalog/Background_Processing/Background_Jobs.yml
@@ -1,7 +1,6 @@
 name: Background Jobs
 description: Process slow tasks asynchronously to keep response times low, improve fault-tolerance and aid with horizontal scaling
 projects:
-  - acts_as_executor
   - backburner
   - barttenbrinke/worker_queue
   - beetle

--- a/catalog/Background_Processing/Background_Jobs.yml
+++ b/catalog/Background_Processing/Background_Jobs.yml
@@ -11,7 +11,6 @@ projects:
   - bunny
   - cloud-crowd
   - delayed_job
-  - delayed_job_active_record
   - frenzy_bunnies
   - girl_friday
   - gnufied/backgroundrb

--- a/catalog/Background_Processing/Background_Jobs.yml
+++ b/catalog/Background_Processing/Background_Jobs.yml
@@ -20,7 +20,6 @@ projects:
   - rock-queue
   - rocketjob
   - runner
-  - seanohalpin/smqueue
   - shoryuken
   - sidekiq
   - sucker_punch

--- a/catalog/Background_Processing/Background_Jobs.yml
+++ b/catalog/Background_Processing/Background_Jobs.yml
@@ -11,7 +11,6 @@ projects:
   - cloud-crowd
   - delayed_job
   - frenzy_bunnies
-  - gnufied/backgroundrb
   - jnstq/job_fu
   - job_reactor
   - later

--- a/catalog/Background_Processing/Background_Jobs.yml
+++ b/catalog/Background_Processing/Background_Jobs.yml
@@ -14,7 +14,6 @@ projects:
   - jnstq/job_fu
   - job_reactor
   - later
-  - navvy
   - ncr/background-fu
   - que
   - quebert

--- a/catalog/Background_Processing/Background_Jobs.yml
+++ b/catalog/Background_Processing/Background_Jobs.yml
@@ -7,7 +7,6 @@ projects:
   - bunny
   - cloud-crowd
   - delayed_job
-  - frenzy_bunnies
   - que
   - quebert
   - queue_classic

--- a/catalog/Background_Processing/Background_Jobs.yml
+++ b/catalog/Background_Processing/Background_Jobs.yml
@@ -17,7 +17,6 @@ projects:
   - queue_classic
   - rabbit_jobs
   - resque
-  - resque-mongo
   - rock-queue
   - rocketjob
   - runner

--- a/catalog/Background_Processing/Background_Jobs.yml
+++ b/catalog/Background_Processing/Background_Jobs.yml
@@ -23,4 +23,3 @@ projects:
   - shoryuken
   - sidekiq
   - sucker_punch
-  - workling

--- a/catalog/Background_Processing/Background_Jobs.yml
+++ b/catalog/Background_Processing/Background_Jobs.yml
@@ -15,7 +15,6 @@ projects:
   - que
   - quebert
   - queue_classic
-  - rabbit_jobs
   - resque
   - rocketjob
   - runner


### PR DESCRIPTION
This PR removes many outdated gems from the "Background Jobs" section, reducing the number of gems from 40 to 13.