### PR TITLE
Add cl to CLI_Option_Parsers.yml

### DIFF
--- a/catalog/Developer_Tools/CLI_Option_Parsers.yml
+++ b/catalog/Developer_Tools/CLI_Option_Parsers.yml
@@ -4,6 +4,7 @@ projects:
   - acclaim
   - arg0
   - choice
+  - cl
   - clamp
   - clap
   - cmdparse


### PR DESCRIPTION
This adds cl. See:

* https://rubygems.org/gems/cl
* https://github.com/svenfuchs/cl
* https://www.rubydoc.info/gems/cl/0.1.24

> Thanks for contributing to the Ruby Toolbox catalog! <3

> **Before submitting your pull request:**

> - [x] If you are submitting a github-based project, please verify the project is not packaged as a rubygem

Not sure I fully understand, but I assume there's a way to submit projects that are not gems? This is a gem, so I suppose this checks out.

> - [x] Please make sure the projects are listed in case-insensitive alphabetical order

Yep, done.

> - [x] Make sure the CI build passes, we validate your proposed changes in the test suite :)

The CI build of ... my gem? Yep, it does: https://travis-ci.org/svenfuchs/cl. Or the CI build of the catalog? I suppose that's gonna run only after I submit the PR? (Edit: it's green)

:)