### PR TITLE
Add the civil_service gem

### DIFF
--- a/catalog/Code_Organization/Service_Objects.yml
+++ b/catalog/Code_Organization/Service_Objects.yml
@@ -2,6 +2,7 @@ name: Service Objects
 description: Libraries to isolate application domain logic into separate classes.
 projects:
   - active_interaction
+  - civil_service
   - dry-transaction
   - interactor
   - mutations


### PR DESCRIPTION
CivilService is a tiny framework for Rails service objects.

Thanks for contributing to the Ruby Toolbox catalog! <3

**Before submitting your pull request:**

- [x] If you are submitting a github-based project, please verify the project is not packaged as a rubygem
- [x] Please make sure the projects are listed in case-insensitive alphabetical order
- [x] Make sure the CI build passes, we validate your proposed changes in the test suite :)
