### PR TITLE
Add math and science category

### DIFF
--- a/catalog/Math_and_Science/Math.yml
+++ b/catalog/Math_and_Science/Math.yml
@@ -1,0 +1,4 @@
+name: Math
+description: Math utilities, tools and extensions
+projects:
+  - continued_fractions

--- a/catalog/Math_and_Science/_meta.yml
+++ b/catalog/Math_and_Science/_meta.yml
@@ -1,0 +1,2 @@
+name: Math and Science
+description: Math and science utilities and tools


### PR DESCRIPTION
Several Ruby gems belong to science and math categories.

This change adds the "Math and Science" category and adds the first of
hopefully other gems to follow under Math.

Thanks for contributing to the Ruby Toolbox catalog! <3

**Before submitting your pull request:**

- [x] If you are submitting a github-based project, please verify the project is not packaged as a rubygem
- [x] Please make sure the projects are listed in case-insensitive alphabetical order
- [x] Make sure the CI build passes, we validate your proposed changes in the test suite :)
