### PR TITLE
Add wor-paginate

### DIFF
--- a/catalog/Active_Record_Plugins/pagination.yml
+++ b/catalog/Active_Record_Plugins/pagination.yml
@@ -10,3 +10,4 @@ projects:
   - simply_paginate
   - sorted
   - will_paginate
+  - wor-paginate


### PR DESCRIPTION
Adds [wor-paginate](https://github.com/Wolox/wor-paginate) gem to pagination category.

**Before submitting your pull request:**

- [x] If you are submitting a github-based project, please verify the project is not packaged as a rubygem
- [x] Please make sure the projects are listed in case-insensitive alphabetical order
- [x] Make sure the CI build passes, we validate your proposed changes in the test suite :)
