### PR TITLE
Create swagger_tools.yml

### DIFF
--- a/catalog/Documentation_Tools/swagger_tools.yml
+++ b/catalog/Documentation_Tools/swagger_tools.yml
@@ -1,0 +1,15 @@
+name: OpenAPI Tools (formerly Swagger)
+description: Tools for creating, serving or testing with OpenAPI documentation or Swagger tooling
+projects:
+  - apivore
+  - grape-swagger
+  - nexmo-oas-renderer
+  - oas_parser
+  - openapi_first
+  - open_api_import
+  - rswag
+  - rswag-api
+  - rswag-ui
+  - rswag-specs
+  - swagger-blocks
+  - swagger-diff

--- a/catalog/Documentation_Tools/swagger_tools.yml
+++ b/catalog/Documentation_Tools/swagger_tools.yml
@@ -5,11 +5,11 @@ projects:
   - grape-swagger
   - nexmo-oas-renderer
   - oas_parser
-  - openapi_first
   - open_api_import
+  - openapi_first
   - rswag
   - rswag-api
-  - rswag-ui
   - rswag-specs
+  - rswag-ui
   - swagger-blocks
   - swagger-diff


### PR DESCRIPTION
Currently there is no category for OpenAPI or Swagger based tools, be that testers, diffs, servers, parsers etc.

Hopefully adding a new subcategory to Documentation Tools category makes sense.
