### PR TITLE
Add "tomo" gem to deployment automation category

### DIFF
--- a/catalog/Provision_Deploy_Host/deployment_automation.yml
+++ b/catalog/Provision_Deploy_Host/deployment_automation.yml
@@ -26,6 +26,7 @@ projects:
   - ruploy
   - saizai/superdeploy
   - shelly
+  - tomo
   - vigil
   - vlad
   - whiskey_disk


### PR DESCRIPTION
Tomo is a friendly CLI for deploying Rails apps.
https://rubygems.org/gems/tomo
https://github.com/mattbrictson/tomo

**Before submitting your pull request:**

- [x] If you are submitting a github-based project, please verify the project is not packaged as a rubygem
- [x] Please make sure the projects are listed in case-insensitive alphabetical order
- [x] Make sure the CI build passes, we validate your proposed changes in the test suite :)
