### PR TITLE
Remove yanked trixy_scopes gem

### DIFF
--- a/catalog/Active_Record_Plugins/Active_Record_Named_Scopes.yml
+++ b/catalog/Active_Record_Plugins/Active_Record_Named_Scopes.yml
@@ -1,5 +1,5 @@
 name: Active Record Named Scopes
-description: 
+description:
 projects:
   - deep_pluck
   - filterrific
@@ -14,5 +14,4 @@ projects:
   - sexy_scopes
   - technoweenie/can_search
   - trailblazer-finder
-  - trixy_scopes
   - utility_scopes


### PR DESCRIPTION
All versions of the `trixy_scopes` gem have been yanked from rubygems.org (see https://rubygems.org/gems/trixy_scopes) and it's causing the Travis CI build to fail. So this PR removes it.

Thanks for contributing to the Ruby Toolbox catalog! <3

**Before submitting your pull request:**

- [x] If you are submitting a github-based project, please verify the project is not packaged as a rubygem
- [x] Please make sure the projects are listed in case-insensitive alphabetical order
- [x] Make sure the CI build passes, we validate your proposed changes in the test suite :)
