### PR TITLE
Remove yanked commenter gem

### DIFF
--- a/catalog/Active_Record_Plugins/rails_comments.yml
+++ b/catalog/Active_Record_Plugins/rails_comments.yml
@@ -2,7 +2,6 @@ name: Rails Comments
 description: 
 projects:
   - acts_as_commentable
-  - commenter
   - commontator
   - disqus
   - elight/acts_as_commentable_with_threading


### PR DESCRIPTION
The commenter gem has been yanked entirely, causing the rspec tests to fail since the gem is referenced here but no longer available on rubygems.

Thanks for contributing to the Ruby Toolbox catalog! <3

**Before submitting your pull request:**

- [x] If you are submitting a github-based project, please verify the project is not packaged as a rubygem
- [x] Please make sure the projects are listed in case-insensitive alphabetical order
- [x] Make sure the CI build passes, we validate your proposed changes in the test suite :)
