### PR TITLE
Add sidekiq-scheduler to Scheduling category

### DIFF
--- a/catalog/Background_Processing/scheduling.yml
+++ b/catalog/Background_Processing/scheduling.yml
@@ -8,6 +8,7 @@ projects:
   - rufus-scheduler
   - sidecloq
   - sidekiq-cron
+  - sidekiq-scheduler
   - simple_scheduler
   - Swirrl/Taskit
   - whenever


### PR DESCRIPTION
Seems like it was accidentally omitted, given the popularity.