### PR TITLE
Add Forme to form builders

### DIFF
--- a/catalog/HTML_Markup/rails_form_builders.yml
+++ b/catalog/HTML_Markup/rails_form_builders.yml
@@ -7,6 +7,7 @@ projects:
   - campo
   - cocoon
   - comfy_bootstrap_form
+  - forme
   - formize
   - formtastic
   - formula


### PR DESCRIPTION
Forme is the only web framework agnostic form builder that I’m aware of, so I thought we could add it to the list.