### PR TITLE
For DynamoDB page, include official AWS package 

### DIFF
--- a/catalog/Data_Persistence/Amazon_DynamoDB.yml
+++ b/catalog/Data_Persistence/Amazon_DynamoDB.yml
@@ -5,3 +5,4 @@ projects:
   - dynamoid
   - dynoid
   - fake_dynamo
+  - aws-record

--- a/catalog/Data_Persistence/Amazon_DynamoDB.yml
+++ b/catalog/Data_Persistence/Amazon_DynamoDB.yml
@@ -2,7 +2,7 @@ name: Amazon DynamoDB
 description: 
 projects:
   - active_dynamodb
+  - aws-record
   - dynamoid
   - dynoid
   - fake_dynamo
-  - aws-record


### PR DESCRIPTION
Since DynamoDB is an AWS product, we should include the official AWS package.

Documentation: https://docs.aws.amazon.com/awssdkrubyrecord/api/

Thanks for contributing to the Ruby Toolbox catalog! <3

**Before submitting your pull request:**

- [ ] If you are submitting a github-based project, please verify the project is not packaged as a rubygem
- [x] Please make sure the projects are listed in case-insensitive alphabetical order
- [x] Make sure the CI build passes, we validate your proposed changes in the test suite :)
