### PR TITLE
add blueprinter to API Builders

### DIFF
--- a/catalog/Web_Apps_Services_Interaction/API_Builders.yml
+++ b/catalog/Web_Apps_Services_Interaction/API_Builders.yml
@@ -6,6 +6,7 @@ projects:
   - api-versions
   - apiary
   - bldr
+  - blueprinter
   - cache_crispies
   - fast_jsonapi
   - grape


### PR DESCRIPTION
Add https://github.com/procore/blueprinter (https://www.ruby-toolbox.com/projects/blueprinter) to API Builders

**Before submitting your pull request:**

- [x] If you are submitting a github-based project, please verify the project is not packaged as a rubygem
- [x] Please make sure the projects are listed in case-insensitive alphabetical order
- [x] Make sure the CI build passes, we validate your proposed changes in the test suite :)
