### PR TITLE
Add yaaf to form objects

### DIFF
--- a/catalog/Code_Organization/Form_Objects.yml
+++ b/catalog/Code_Organization/Form_Objects.yml
@@ -6,3 +6,4 @@ projects:
   - reform
   - scrivener
   - virtus
+  - yaaf


### PR DESCRIPTION
Hi everyone, I'd like to add `yaaf` to the list of form object gems available. It's a pretty new gem but it has been an abstraction from production, so it's ready for production use for others too. It's just 64 lines of code long and that's what makes it different from other solutions. For more info you can check out the `README`, we have put some love there with @juanmanuelramallo . Hope you accept it, thanks 😄 