### PR TITLE
Add 3 gems to Code Metrics

### DIFF
--- a/catalog/Code_Quality/code_metrics.yml
+++ b/catalog/Code_Quality/code_metrics.yml
@@ -11,6 +11,7 @@ projects:
   - flay
   - flog
   - foodcritic
+  - fukuzatsu
   - git-cop
   - jslint_on_rails
   - kevinrutherford/crap4r
@@ -27,5 +28,7 @@ projects:
   - rubycritic
   - Saikuro
   - sandi_meter
+  - skunk
+  - snuffle
   - tailor
   - thoughtbot/report_card


### PR DESCRIPTION
https://www.ruby-toolbox.com/categories/code_metrics

1. https://github.com/fastruby/skunk: A StinkScore Calculator for Ruby Code.
2. https://github.com/CoralineAda/fukuzatsu: A tool for measuring code complexity in Ruby class files. Its analysis generates scores based on cyclomatic complexity algorithms with no added "opinions".
3. https://github.com/CoralineAda/snuffle: Snuffle analyzes code to search out latent objects for extraction.

Thanks for contributing to the Ruby Toolbox catalog! <3

**Before submitting your pull request:**

- [x] If you are submitting a github-based project, please verify the project is not packaged as a rubygem
- [x] Please make sure the projects are listed in case-insensitive alphabetical order
- [ ] Make sure the CI build passes, we validate your proposed changes in the test suite :)
