### PR TITLE
Correct gem name mistake made by me in #380

### DIFF
--- a/catalog/Documents_Reports/reporting.yml
+++ b/catalog/Documents_Reports/reporting.yml
@@ -39,4 +39,4 @@ projects:
   - wrap_excel
   - write_xlsx
   - write_xlsx_rails
-  - xlsx
+  - xsv


### PR DESCRIPTION
I accidentally miswrote the name of my gem Xsv (an xlsx reader) in my earlier PR. This fixes that.

Thanks for contributing to the Ruby Toolbox catalog! <3

**Before submitting your pull request:**

- [x] If you are submitting a github-based project, please verify the project is not packaged as a rubygem
- [x] Please make sure the projects are listed in case-insensitive alphabetical order
- [x] Make sure the CI build passes, we validate your proposed changes in the test suite :)
