### PR TITLE
Reword confusing PR template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,6 @@ Thanks for contributing to the Ruby Toolbox catalog! <3
 
 **Before submitting your pull request:**
 
-- [ ] If you are submitting a github-based project, please verify the project is not packaged as a rubygem
+- [ ] If you are submitting a github-based project, please verify the project is packaged as a rubygem
 - [ ] Please make sure the projects are listed in case-insensitive alphabetical order
 - [ ] Make sure the CI build passes, we validate your proposed changes in the test suite :)

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,8 @@ Thanks for contributing to the Ruby Toolbox catalog! <3
 
 **Before submitting your pull request:**
 
-- [ ] If you are submitting a github-based project, please verify the project is packaged as a rubygem
+- [ ] If you're referencing a gem by its GitHub repository (e.g. `rails/rails`), please verify
+      that it is _not_ packaged as a Ruby gem. (If it _is_ packaged as a gem, please reference it
+      by its gem name instead, e.g. `rails`.)
 - [ ] Please make sure the projects are listed in case-insensitive alphabetical order
 - [ ] Make sure the CI build passes, we validate your proposed changes in the test suite :)


### PR DESCRIPTION
Surely contributors should verify that their project _is_ packaged as a rubygem, not that it isn't.

Thanks for contributing to the Ruby Toolbox catalog! <3

**Before submitting your pull request:**

- [x] If you are submitting a github-based project, please verify the project is not packaged as a rubygem
- [x] Please make sure the projects are listed in case-insensitive alphabetical order
- [x] Make sure the CI build passes, we validate your proposed changes in the test suite :)
