### PR TITLE
Add str_enum project to category

### DIFF
--- a/catalog/Active_Record_Plugins/Active_Record_Enumerations.yml
+++ b/catalog/Active_Record_Plugins/Active_Record_Enumerations.yml
@@ -14,3 +14,4 @@ projects:
   - enumify
   - power_enum
   - simple_enum
+  - str_enum


### PR DESCRIPTION
Thanks for contributing to the Ruby Toolbox catalog! <3

**Before submitting your pull request:**

- [X] If you are submitting a github-based project, please verify the project is not packaged as a rubygem
- [X] Please make sure the projects are listed in case-insensitive alphabetical order
- [X] Make sure the CI build passes, we validate your proposed changes in the test suite*

*I don't own the `str_enum` gem, I just noticed it was missing from this category. It was last updated 03/18/20 and has no open issues so I'm thinking it's pretty safe, especially since it's also already in your general catalog.
