### PR TITLE
Add  jsonapi-serializer

### DIFF
--- a/catalog/Web_Apps_Services_Interaction/API_Builders.yml
+++ b/catalog/Web_Apps_Services_Interaction/API_Builders.yml
@@ -13,6 +13,7 @@ projects:
   - grapethor
   - jb
   - jbuilder
+  - jsonapi-serializer
   - mutils
   - nativeson
   - rabl


### PR DESCRIPTION
This the fork of Netflix/fast_jsonapi that isn’t being maintained as mentioned in https://github.com/Netflix/fast_jsonapi/issues/433#issuecomment-538056076

- [x] If you're referencing a gem by its GitHub repository (e.g. `rails/rails`), please verify
      that it is _not_ packaged as a Ruby gem. (If it _is_ packaged as a gem, please reference it
      by its gem name instead, e.g. `rails`.)
- [x] Please make sure the projects are listed in case-insensitive alphabetical order
- [x] Make sure the CI build passes, we validate your proposed changes in the test suite :)
