### PR TITLE
Categorize cuke_linter gem under Cucumber Tools

### DIFF
--- a/catalog/Testing/Cucumber_Tools.yml
+++ b/catalog/Testing/Cucumber_Tools.yml
@@ -11,6 +11,7 @@ projects:
   - cucumber-sinatra
   - cucumberator
   - cuke_cataloger
+  - cuke_linter
   - cuke_modeler
   - cuke_sniffer
   - cukesparse


### PR DESCRIPTION
Thanks for contributing to the Ruby Toolbox catalog! <3

**Before submitting your pull request:**

- [x] If you're referencing a gem by its GitHub repository (e.g. `rails/rails`), please verify
      that it is _not_ packaged as a Ruby gem. (If it _is_ packaged as a gem, please reference it
      by its gem name instead, e.g. `rails`.)
- [x] Please make sure the projects are listed in case-insensitive alphabetical order
- [x] Make sure the CI build passes, we validate your proposed changes in the test suite :)
