### PR TITLE
add category strings including project

### DIFF
--- a/catalog/Data_Analysis/strings.yml
+++ b/catalog/Data_Analysis/strings.yml
@@ -1,0 +1,4 @@
+name: Strings
+description: String tools for manipulation, decoding, encoding, verifying, generation, letter case, etc.
+projects:
+  - lucky_case

--- a/catalog/Data_Analysis/strings.yml
+++ b/catalog/Data_Analysis/strings.yml
@@ -1,4 +1,7 @@
 name: Strings
 description: String tools for manipulation, decoding, encoding, verifying, generation, letter case, etc.
 projects:
+  - jaro_winkler
   - lucky_case
+  - numerizer
+  - sanitize


### PR DESCRIPTION
Thanks for contributing to the Ruby Toolbox catalog! <3

**Before submitting your pull request:**

- [x] If you're referencing a gem by its GitHub repository (e.g. `rails/rails`), please verify
      that it is _not_ packaged as a Ruby gem. (If it _is_ packaged as a gem, please reference it
      by its gem name instead, e.g. `rails`.)
- [x] Please make sure the projects are listed in case-insensitive alphabetical order
- [x] Make sure the CI build passes, we validate your proposed changes in the test suite :)
