### PR TITLE
Update RSpec_Matchers.yml

### DIFF
--- a/catalog/Testing/RSpec_Matchers.yml
+++ b/catalog/Testing/RSpec_Matchers.yml
@@ -11,6 +11,7 @@ projects:
   - rspec-html-matchers
   - rspec-instrumentation-matcher
   - rspec-json_matcher
+  - rspec-log_matcher
   - rspec-mail_matcher
   - rspec-pgp_matchers
   - shoulda-matchers


### PR DESCRIPTION
Adding rspec-log_matcher, an RSpec custom matcher to test code that logs information into log files.
https://github.com/juanmanuelramallo/rspec-log_matcher

- [x] If you're referencing a gem by its GitHub repository (e.g. `rails/rails`), please verify
      that it is _not_ packaged as a Ruby gem. (If it _is_ packaged as a gem, please reference it
      by its gem name instead, e.g. `rails`.)
- [x] Please make sure the projects are listed in case-insensitive alphabetical order
- [x] Make sure the CI build passes, we validate your proposed changes in the test suite :)
