### PR TITLE
Add ExceptionHunter

### DIFF
--- a/catalog/Maintenance_Monitoring/exception_notification.yml
+++ b/catalog/Maintenance_Monitoring/exception_notification.yml
@@ -5,6 +5,7 @@ projects:
   - bugsnag
   - errbit/errbit
   - exception_engine
+  - exception_hunter
   - exception_notification
   - exceptional
   - honeybadger


### PR DESCRIPTION
Hey, I just wanted to see if I could add ExceptionHunter to the list of gems under the `Exception Notification` category. It's a pretty new gem but I trust it'll prove useful for some people.

Thanks to @t-romani for all the help too ❤️ 
