### PR TITLE
Add `erd` to Rails Class Diagrams

### DIFF
--- a/catalog/Rails_Plugins/Rails_Class_Diagrams.yml
+++ b/catalog/Rails_Plugins/Rails_Class_Diagrams.yml
@@ -1,5 +1,6 @@
 name: Rails Class Diagrams
 description: 
 projects:
+  - erd
   - railroady
   - rails-erd


### PR DESCRIPTION
This is for ERD diagrams. And it's relatively popular
https://rubygems.org/search?utf8=%E2%9C%93&query=erd

Thanks for contributing to the Ruby Toolbox catalog! <3

**Before submitting your pull request:**

- [x] If you're referencing a gem by its GitHub repository (e.g. `rails/rails`), please verify
      that it is _not_ packaged as a Ruby gem. (If it _is_ packaged as a gem, please reference it
      by its gem name instead, e.g. `rails`.)
- [x] Please make sure the projects are listed in case-insensitive alphabetical order
- [ ] Make sure the CI build passes, we validate your proposed changes in the test suite :)
