### PR TITLE
Add the "Active Record Timestamps" section

### DIFF
--- a/catalog/Active_Record_Plugins/Active_Record_Timestamps.yml
+++ b/catalog/Active_Record_Plugins/Active_Record_Timestamps.yml
@@ -1,0 +1,8 @@
+name: Active Record Timestamps
+description: Use timestamp values to represent boolean data
+projects:
+  - active_record-events
+  - bool_at
+  - boole_time
+  - boolean_timestamp
+  - time_for_a_boolean


### PR DESCRIPTION
Hey! I wonder if we could add a new section under the *Active Record Plugins* category to group gems responsible for managing timestamp fields in ActiveRecord models.

I wrote such a library myself (it's called [active_record-events](https://github.com/pienkowb/active_record-events)), but I also found 4 other gems doing basically the same thing. It makes me think the idea is popular enough to consider adding a subcategory.

I listed all of the gems in this pull request.