### PR TITLE
Add CuttingEdge to Dependency Management category

### DIFF
--- a/catalog/Package_Dependency_Management/dependency_management.yml
+++ b/catalog/Package_Dependency_Management/dependency_management.yml
@@ -7,6 +7,7 @@ projects:
   - brewdler
   - bundler
   - checkzilla
+  - cutting_edge
   - externals
   - gemrat
   - giternal
@@ -15,4 +16,3 @@ projects:
   - librarian
   - motion-bundler
   - piston
-  - cutting_edge

--- a/catalog/Package_Dependency_Management/dependency_management.yml
+++ b/catalog/Package_Dependency_Management/dependency_management.yml
@@ -15,3 +15,4 @@ projects:
   - librarian
   - motion-bundler
   - piston
+  - cutting_edge


### PR DESCRIPTION
Adding [CuttingEdge](https://github.com/repotag/cutting_edge), a new dependency management tool, to the relevant category. :)

**Before submitting your pull request:**

- [X] If you're referencing a gem by its GitHub repository (e.g. `rails/rails`), please verify
      that it is _not_ packaged as a Ruby gem. (If it _is_ packaged as a gem, please reference it
      by its gem name instead, e.g. `rails`.)
- [X] Please make sure the projects are listed in case-insensitive alphabetical order
- [X] Make sure the CI build passes, we validate your proposed changes in the test suite :)
