### PR TITLE
Rails presenters

### DIFF
--- a/catalog/Code_Quality/code_metrics.yml
+++ b/catalog/Code_Quality/code_metrics.yml
@@ -12,7 +12,6 @@ projects:
   - flog
   - foodcritic
   - fukuzatsu
-  - git-cop
   - jslint_on_rails
   - kevinrutherford/crap4r
   - metric_abc

--- a/catalog/Developer_Tools/git_Tools.yml
+++ b/catalog/Developer_Tools/git_Tools.yml
@@ -4,7 +4,6 @@ projects:
   - ezgit
   - gas
   - git
-  - git-cop
   - git_curate
   - githug
   - gitolite

--- a/catalog/HTTP_API_Clients/api_clients.yml
+++ b/catalog/HTTP_API_Clients/api_clients.yml
@@ -26,7 +26,6 @@ projects:
   - fql
   - freshbooks
   - freshbooks.rb
-  - freshbooks2
   - gibbon
   - github_api
   - gnip-rule

--- a/catalog/Maintenance_Monitoring/rails_instrumentation.yml
+++ b/catalog/Maintenance_Monitoring/rails_instrumentation.yml
@@ -17,7 +17,6 @@ projects:
   - newrelic_rpm
   - nunes
   - peek
-  - query_trace
   - rack-bug
   - rack-insight
   - rackamole

--- a/catalog/Rails_Plugins/rails_presenters.yml
+++ b/catalog/Rails_Plugins/rails_presenters.yml
@@ -7,6 +7,7 @@ projects:
   - apotomo
   - cells
   - classic_presenter
+  - dekorator
   - delegate_presenter
   - display_case
   - draper
@@ -14,6 +15,7 @@ projects:
   - komponent
   - meta_presenter
   - oprah
+  - pres
   - rails_presenter
   - resubject
   - view_models


### PR DESCRIPTION
Add two decorator gems

1. dekorator
2. pres

Remove yanked (or) owner removed gems

1. freshbooks2
2. git-cop
3. query_trace

**Before submitting your pull request:**

- [x ] If you're referencing a gem by its GitHub repository (e.g. `rails/rails`), please verify
      that it is _not_ packaged as a Ruby gem. (If it _is_ packaged as a gem, please reference it
      by its gem name instead, e.g. `rails`.)
- [x] Please make sure the projects are listed in case-insensitive alphabetical order
- [x] Make sure the CI build passes, we validate your proposed changes in the test suite :)
