### PR TITLE
Remove dropped gems

### DIFF
--- a/catalog/Code_Quality/code_metrics.yml
+++ b/catalog/Code_Quality/code_metrics.yml
@@ -12,7 +12,6 @@ projects:
   - flog
   - foodcritic
   - fukuzatsu
-  - git-cop
   - jslint_on_rails
   - kevinrutherford/crap4r
   - metric_abc

--- a/catalog/Developer_Tools/git_Tools.yml
+++ b/catalog/Developer_Tools/git_Tools.yml
@@ -4,7 +4,6 @@ projects:
   - ezgit
   - gas
   - git
-  - git-cop
   - git_curate
   - githug
   - gitolite

--- a/catalog/HTTP_API_Clients/api_clients.yml
+++ b/catalog/HTTP_API_Clients/api_clients.yml
@@ -26,7 +26,6 @@ projects:
   - fql
   - freshbooks
   - freshbooks.rb
-  - freshbooks2
   - gibbon
   - github_api
   - gnip-rule

--- a/catalog/Maintenance_Monitoring/rails_instrumentation.yml
+++ b/catalog/Maintenance_Monitoring/rails_instrumentation.yml
@@ -17,7 +17,6 @@ projects:
   - newrelic_rpm
   - nunes
   - peek
-  - query_trace
   - rack-bug
   - rack-insight
   - rackamole


### PR DESCRIPTION
A few referenced gems have been removed by their owners from rubygems, breaking the build:

```
  1) Catalog referenced rubygems references only actually existing gems
     Failure/Error: expect(referenced_gems - available_gems).to be == []
       expected: == []
            got:    ["freshbooks2", "git-cop", "git-cop", "query_trace"]
     # ./spec/catalog_spec.rb:67:in `block (3 levels) in <top (required)>'
```

This PR removes them from the catalog