### PR TITLE
Adding xlsx_drone to Documents_Reports/reporting

### DIFF
--- a/catalog/Documents_Reports/reporting.yml
+++ b/catalog/Documents_Reports/reporting.yml
@@ -39,4 +39,5 @@ projects:
   - wrap_excel
   - write_xlsx
   - write_xlsx_rails
+  - xlsx_drone
   - xsv


### PR DESCRIPTION
xlsx_drone is a fast Microsoft Excel's XLSX reader. Binding of C's xlsx_drone lib.

- [x ] If you're referencing a gem by its GitHub repository (e.g. `rails/rails`), please verify
      that it is _not_ packaged as a Ruby gem. (If it _is_ packaged as a gem, please reference it
      by its gem name instead, e.g. `rails`.)
- [ x] Please make sure the projects are listed in case-insensitive alphabetical order
- [ x] Make sure the CI build passes, we validate your proposed changes in the test suite :)
