### PR TITLE
Add que-scheduler to Background Processing (Scheduling) category

### DIFF
--- a/catalog/Background_Processing/scheduling.yml
+++ b/catalog/Background_Processing/scheduling.yml
@@ -3,6 +3,7 @@ description: Execute tasks on a schedule
 projects:
   - clockwork
   - latimes/craken
+  - que-scheduler
   - recurrent
   - resque-scheduler
   - rufus-scheduler


### PR DESCRIPTION
Thanks for contributing to the Ruby Toolbox catalog! <3

**Before submitting your pull request:**

- [ x] If you're referencing a gem by its GitHub repository (e.g. `rails/rails`), please verify
      that it is _not_ packaged as a Ruby gem. (If it _is_ packaged as a gem, please reference it
      by its gem name instead, e.g. `rails`.)
- [x ] Please make sure the projects are listed in case-insensitive alphabetical order
- [x ] Make sure the CI build passes, we validate your proposed changes in the test suite :)

This adds que-scheduler: https://github.com/hlascelles/que-scheduler
