### PR TITLE
Add keyset pagination libraries to Pagination

### DIFF
--- a/catalog/Active_Record_Plugins/pagination.yml
+++ b/catalog/Active_Record_Plugins/pagination.yml
@@ -4,9 +4,12 @@ projects:
   - ajax_pagination
   - kaminari
   - kaminari-bootstrap
+  - nexter
+  - order_query
   - paged_scopes
   - pagy
   - pagy-extras
+  - sequel-seek-pagination
   - simply_paginate
   - sorted
   - will_paginate


### PR DESCRIPTION
I learned of these libraries from the links in https://use-the-index-luke.com/no-offset#frameworks .

At least one of these libraries is unmaintained now, but I think all these libraries are worth adding to the Pagination category so that designers of future pagination libraries can reference their designs.

Links to the Ruby Toolbox pages for the added libraries:

- https://www.ruby-toolbox.com/projects/nexter
- https://www.ruby-toolbox.com/projects/order_query
- https://www.ruby-toolbox.com/projects/sequel-seek-pagination