### PR TITLE
Remove yanked gem; fixes current CI failures

### DIFF
--- a/catalog/Provision_Deploy_Host/Microsoft_Azure.yml
+++ b/catalog/Provision_Deploy_Host/Microsoft_Azure.yml
@@ -8,7 +8,6 @@ projects:
   - azure-core
   - azure-credentials
   - azure-directory
-  - azure-documentdb-sdk
   - azure-fix
   - azure-loganalytics-datacollector-api
   - azure-multistorage


### PR DESCRIPTION
See https://rubygems.org/gems/azure-documentdb-sdk/versions - all versions yanked.