### PR TITLE
Add science gems to catalog

### DIFF
--- a/catalog/Data_Analysis/analysis.yml
+++ b/catalog/Data_Analysis/analysis.yml
@@ -1,0 +1,8 @@
+name: Analysis
+description: Projects for doing data analysis
+projects:
+  - daru
+  - statsample
+  - statsample-bivariate-extension
+  - statsample-glm
+  - statsample-timeseries

--- a/catalog/Data_Analysis/numerical.yml
+++ b/catalog/Data_Analysis/numerical.yml
@@ -2,6 +2,9 @@ name: Numerical
 description: Projects for doing number manipulation.
 projects:
   - cumo
+  - integration
+  - minimization
   - numo
   - numo-libsvm
   - numo-narray
+  - rb-gsl

--- a/catalog/Data_Analysis/structures.yml
+++ b/catalog/Data_Analysis/structures.yml
@@ -1,7 +1,5 @@
 name: Structures
 description: Projects for working with data structures such as vectors and data frames.
 projects:
-  - daru
   - daru-io
-  - daru-view
   - rasn1

--- a/catalog/Data_Analysis/visualization.yml
+++ b/catalog/Data_Analysis/visualization.yml
@@ -1,0 +1,6 @@
+name: Visualization
+description: Projects for visualizing data
+projects:
+  - daru-view
+  - iruby
+  - iruby-rails

--- a/catalog/Graphics/graphing.yml
+++ b/catalog/Graphics/graphing.yml
@@ -4,9 +4,11 @@ projects:
   - adamwiggins/rifgraf
   - apexcharts
   - chartkick
+  - charty
   - gchart
   - gchartrb
   - gnuplot
+  - gnuplotr
   - gnuplotrb
   - google_charts
   - google_visualr
@@ -15,11 +17,16 @@ projects:
   - gruff
   - highcharts-rails
   - lazy_high_charts
+  - matplotlib
   - numo-gnuplot
   - numplot
+  - nyaplot
   - ofc2
+  - plotlyrb
   - pullmonkey/open_flash_chart
+  - rbplotly
   - rchart
+  - ruby-gr
   - rubyplot
   - rubyvis
   - scbi_plot
@@ -29,3 +36,4 @@ projects:
   - squid
   - technical_graph
   - triangle_pattern
+  - vega

--- a/catalog/Machine_Learning/Machine_Learning.yml
+++ b/catalog/Machine_Learning/Machine_Learning.yml
@@ -1,0 +1,4 @@
+name: Machine Learning
+description: Libraries and Frameworks to train and apply machine learning models to general problems
+projects:
+  - rumale

--- a/catalog/Math_and_Science/Math.yml
+++ b/catalog/Math_and_Science/Math.yml
@@ -2,3 +2,7 @@ name: Math
 description: Math utilities, tools and extensions
 projects:
   - continued_fractions
+  - integration
+  - minimization
+  - nmatrix
+  - rb-gsl

--- a/catalog/Provision_Deploy_Host/Microsoft_Azure.yml
+++ b/catalog/Provision_Deploy_Host/Microsoft_Azure.yml
@@ -8,7 +8,6 @@ projects:
   - azure-core
   - azure-credentials
   - azure-directory
-  - azure-documentdb-sdk
   - azure-fix
   - azure-loganalytics-datacollector-api
   - azure-multistorage


### PR DESCRIPTION
Some science gems are missing from the catalog.

This commit:

1. Adds to the Data Analysis/Analysis category:
- statsample
- statsample-bivariate-extension
- statsample-glm
- statsample-timeseries

2. Adds to the Data Analysis/Visualization category:
- iruby
- iruby-rails

3. Adds to the Data Analysis/Numerical and Math and Science/Math categories:
- integration
- minimization
- nmatrix
- rb-gsl

4. Adds to the Graphics/Graphing category:
- charty
- gnuplotr
- matplotlib
- nyaplot
- plotlyrb
- rbplotly
- ruby-gr
- vega

5. Adds to Machine Learning/Machine Learning category:
- rumale

Thanks for contributing to the Ruby Toolbox catalog! <3

**Before submitting your pull request:**

- [x] If you're referencing a gem by its GitHub repository (e.g. `rails/rails`), please verify
      that it is _not_ packaged as a Ruby gem. (If it _is_ packaged as a gem, please reference it
      by its gem name instead, e.g. `rails`.)
- [x] Please make sure the projects are listed in case-insensitive alphabetical order
- [x] Make sure the CI build passes, we validate your proposed changes in the test suite :)
