### PR TITLE
Added caxlsx

### DIFF
--- a/catalog/Documents_Reports/reporting.yml
+++ b/catalog/Documents_Reports/reporting.yml
@@ -5,6 +5,7 @@ projects:
   - acts_as_xlsx
   - axlsx 
   - axlsx_rails
+  - caxlsx
   - compendium
   - creek
   - dossier


### PR DESCRIPTION
Added caxlsx which is the better maintained Axlsx

Thanks for contributing to the Ruby Toolbox catalog! <3

**Before submitting your pull request:**

- [ ] If you're referencing a gem by its GitHub repository (e.g. `rails/rails`), please verify
      that it is _not_ packaged as a Ruby gem. (If it _is_ packaged as a gem, please reference it
      by its gem name instead, e.g. `rails`.)
- [ ] Please make sure the projects are listed in case-insensitive alphabetical order
- [ ] Make sure the CI build passes, we validate your proposed changes in the test suite :)
