### PR TITLE
Switch GitHub workflows to using bundler-cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,24 +13,14 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Restore dependency cache
-      uses: actions/cache@v2
-      with:
-        path: |
-          vendor/bundle
-        key: ${{ runner.os }}-gems
-        restore-keys: |
-          ${{ runner.os }}-gems
     - uses: ruby/setup-ruby@v1
-    - name: Install dependencies and run bundler-audit
+      with:
+        bundler-cache: true
+    - name: Run bundler-audit
       env:
         # Neccessary for jruby test coverage
         JRUBY_OPTS: "--debug"
-      run: |
-        gem install bundler
-        bundle config set path 'vendor/bundle'
-        bundle install --jobs 4 --retry 3
-        bundle exec bundler-audit --update
+      run: bundle exec bundler-audit --update
 
   rubocop:
     runs-on: ubuntu-latest
@@ -39,24 +29,14 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Restore dependency cache
-      uses: actions/cache@v2
-      with:
-        path: |
-          vendor/bundle
-        key: ${{ runner.os }}-gems
-        restore-keys: |
-          ${{ runner.os }}-gems
     - uses: ruby/setup-ruby@v1
+      with:
+        bundler-cache: true
     - name: Install dependencies and run rubocop
       env:
         # Neccessary for jruby test coverage
         JRUBY_OPTS: "--debug"
-      run: |
-        gem install bundler
-        bundle config set path 'vendor/bundle'
-        bundle install --jobs 4 --retry 3
-        bundle exec rubocop
+      run: bundle exec rubocop
 
   rspec:
     runs-on: ubuntu-latest
@@ -65,21 +45,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Restore dependency cache
-      uses: actions/cache@v2
-      with:
-        path: |
-          vendor/bundle
-        key: ${{ runner.os }}-gems
-        restore-keys: |
-          ${{ runner.os }}-gems
     - uses: ruby/setup-ruby@v1
+      with:
+        bundler-cache: true
     - name: Install dependencies and run RSpec
-      run: |
-        gem install bundler
-        bundle config set path 'vendor/bundle'
-        bundle install --jobs 4 --retry 3
-        bundle exec rspec
+      run: bundle exec rspec
 
     - uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,21 +18,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Restore dependency cache
-      uses: actions/cache@v2
-      with:
-        path: |
-          vendor/bundle
-        key: ${{ runner.os }}-gems
-        restore-keys: |
-          ${{ runner.os }}-gems
     - uses: ruby/setup-ruby@v1
-    - name: Install dependencies and build catalog export
-      run: |
-        gem install bundler
-        bundle config set path 'vendor/bundle'
-        bundle install --jobs 4 --retry 3
-        bundle exec rake export
+      with:
+        bundler-cache: true
+
+    - name: Build catalog export
+      run: bundle exec rake export
 
     - name: Deploy 🚀
       uses: JamesIves/github-pages-deploy-action@3.7.1


### PR DESCRIPTION
I noticed you were using the cache action, but ruby/setup-ruby now supports bundler-cache and will take care of this for you.

This is just a suggestion, but it's nice to have less config. Also it runs very slightly faster.