### PR TITLE
Add simdjson to json parsers category

### DIFF
--- a/catalog/Web_Apps_Services_Interaction/JSON_Parsers.yml
+++ b/catalog/Web_Apps_Services_Interaction/JSON_Parsers.yml
@@ -8,4 +8,5 @@ projects:
   - json_pure
   - multi_json
   - oj
+  - simdjson
   - yajl-ruby


### PR DESCRIPTION
simdjson is known as one of the fastest c++ implementations of json parsers, and it has a nice ruby wrapper https://www.ruby-toolbox.com/projects/simdjson
I would make all the sense to include it in this category