### PR TITLE
Add motor-admin to Rails Admin Interfaces

### DIFF
--- a/catalog/Rails_Plugins/rails_admin_interfaces.yml
+++ b/catalog/Rails_Plugins/rails_admin_interfaces.yml
@@ -17,6 +17,7 @@ projects:
   - inline_forms
   - lipsiadmin
   - mission_kontrol_relay
+  - motor-admin
   - puffer
   - qadmin
   - rails_admin


### PR DESCRIPTION
Thanks for contributing to the Ruby Toolbox catalog! <3

**Before submitting your pull request:**

- [x] If you're referencing a gem by its GitHub repository (e.g. `rails/rails`), please verify
      that it is _not_ packaged as a Ruby gem. (If it _is_ packaged as a gem, please reference it
      by its gem name instead, e.g. `rails`.)
- [x] Please make sure the projects are listed in case-insensitive alphabetical order
- [ ] Make sure the CI build passes, we validate your proposed changes in the test suite :)
