### PR TITLE
Update GUI_Frameworks.yml

### DIFF
--- a/catalog/Developer_Tools/GUI_Frameworks.yml
+++ b/catalog/Developer_Tools/GUI_Frameworks.yml
@@ -7,6 +7,7 @@ projects:
   - glimmer
   - gtk2
   - gtk3
+  - libui
   - qtbindings
   - shoes
   - wxruby


### PR DESCRIPTION
the libui gem is already included in the toolbox, but not listed in the GUI framework category