### PR TITLE
Add gems to OpenAPI Tools

### DIFF
--- a/catalog/Documentation_Tools/swagger_tools.yml
+++ b/catalog/Documentation_Tools/swagger_tools.yml
@@ -8,6 +8,8 @@ projects:
   - oas_parser
   - open_api_import
   - openapi_first
+  - openapi_parser
+  - rspec-openapi
   - rswag
   - rswag-api
   - rswag-specs


### PR DESCRIPTION
Thanks for contributing to the Ruby Toolbox catalog! <3

**Before submitting your pull request:**

- [x] If you're referencing a gem by its GitHub repository (e.g. `rails/rails`), please verify
      that it is _not_ packaged as a Ruby gem. (If it _is_ packaged as a gem, please reference it
      by its gem name instead, e.g. `rails`.)
- [x] Please make sure the projects are listed in case-insensitive alphabetical order
- [ ] Make sure the CI build passes, we validate your proposed changes in the test suite :)
