### PR TITLE
improve information fetch from gitlab

### DIFF
--- a/spec/catalog_spec.rb
+++ b/spec/catalog_spec.rb
@@ -3,7 +3,7 @@
 require "pp"
 require "tempfile"
 require "rubygems"
-require "rubygems/remote_fetcher"
+require "rubygems/remote_fetcher "
 require "rubygems/name_tuple"
 
 RSpec.describe Catalog do


### PR DESCRIPTION
PS: I'm sorry it's a fake PR since the issue tracker and discussion panel are disabled.

I noticed that when a project is referred by its ruby gem name in the project YAML file, the ruby gem spec are extracted from Rubygems to extract the  `source_code_uri` from `spec.metadata` (and maybe a fallback to `spec.homepage`).

Then information and stats about the project are fetched to display on the project card.

If the project `source_code_uri` is a **github** URL, information from Rubygems (in green) and from the source repository (in red) is displayed:

![image](https://user-images.githubusercontent.com/16578570/123928237-048f0f80-d98e-11eb-9b68-328ed38c9c19.png)

If the project `source_code_uri` is a **gitlab** URL, only information from Rubygems (in green) is displayed and information rom the source repository (in red) is not:

![image](https://user-images.githubusercontent.com/16578570/123928282-107ad180-d98e-11eb-842a-2b1f619bb86a.png)

But the number of stars, forks and watchers are easily fechtable on gitlab too, and activity stats should also.

So I wanted to look at whats done for github URL in the source code and do the same for Gitlab but I can't find the code doing that. It must be implicitly done by a dependency?
