### PR TITLE
add zabbix-api-simplle to HTTP_API_Clients

### DIFF
--- a/catalog/HTTP_API_Clients/api_clients.yml
+++ b/catalog/HTTP_API_Clients/api_clients.yml
@@ -86,4 +86,5 @@ projects:
   - webfinger
   - www-delicious
   - youtube_it
+  - zabbix-api-simple
   - zeus-api


### PR DESCRIPTION
This adds the gem zabbix-api-simple to the http apis category
