### PR TITLE
Add apia to API builders

### DIFF
--- a/catalog/Web_Apps_Services_Interaction/API_Builders.yml
+++ b/catalog/Web_Apps_Services_Interaction/API_Builders.yml
@@ -4,6 +4,7 @@ projects:
   - active_model_serializers
   - acts_as_api
   - api-versions
+  - apia
   - apiary
   - bldr
   - blueprinter


### PR DESCRIPTION
Apia is an opinionated framework for building HTTP APIs into a Ruby application

- Website: https://apia.k.io
- Repository: https://github.com/krystal/apia