### PR TITLE
Add oj_serializers to API builders

### DIFF
--- a/catalog/Web_Apps_Services_Interaction/API_Builders.yml
+++ b/catalog/Web_Apps_Services_Interaction/API_Builders.yml
@@ -16,6 +16,7 @@ projects:
   - jsonapi-serializer
   - mutils
   - nativeson
+  - oj_serializers
   - rabl
   - representable
   - roar


### PR DESCRIPTION
⚡️ Faster JSON serialization for Ruby on Rails. Easily migrate away from Active Model Serializers.

Repo: https://github.com/ElMassimo/oj_serializers
Design & Comparison with other libraries: https://github.com/ElMassimo/oj_serializers#design-
Migrating from ActiveModelSerializers: https://github.com/ElMassimo/oj_serializers/blob/master/MIGRATION_GUIDE.md
