### PR TITLE
Add drg_cms gem

### DIFF
--- a/catalog/Code_Organization/Business_Logic_Frameworks.yml
+++ b/catalog/Code_Organization/Business_Logic_Frameworks.yml
@@ -4,3 +4,4 @@ projects:
   - pathway
   - trailblazer
   - zertico
+  - drg_cms


### PR DESCRIPTION
DRG is much more than CMS. It is tool for rapid building of in-house (business, intranet, private cloud) applications. Data entry forms generated by DRG Forms are far more then simple Rails view forms. They define browsing and editing fields in single YAML file and are tightly coupled with data access policies for accessing data.

Thanks for contributing to the Ruby Toolbox catalog! <3

**Before submitting your pull request:**

- [x] If you're referencing a gem by its GitHub repository (e.g. `rails/rails`), please verify
      that it is _not_ packaged as a Ruby gem. (If it _is_ packaged as a gem, please reference it
      by its gem name instead, e.g. `rails`.)
- [x] Please make sure the projects are listed in case-insensitive alphabetical order
- [x] Make sure the CI build passes, we validate your proposed changes in the test suite :)
