### PR TITLE
Add `delayed` gem to "Background Jobs"

### DIFF
--- a/catalog/Background_Processing/Background_Jobs.yml
+++ b/catalog/Background_Processing/Background_Jobs.yml
@@ -10,6 +10,7 @@ projects:
   - bj
   - bunny
   - cloud-crowd
+  - delayed
   - delayed_job
   - delayed_job_active_record
   - frenzy_bunnies


### PR DESCRIPTION
https://github.com/Betterment/delayed

Thanks for contributing to the Ruby Toolbox catalog! <3

**Before submitting your pull request:**

- [X] If you're referencing a gem by its GitHub repository (e.g. `rails/rails`), please verify
      that it is _not_ packaged as a Ruby gem. (If it _is_ packaged as a gem, please reference it
      by its gem name instead, e.g. `rails`.)
- [X] Please make sure the projects are listed in case-insensitive alphabetical order
- [ ] Make sure the CI build passes, we validate your proposed changes in the test suite :)
