### PR TITLE
Add drg_cms gem

### DIFF
--- a/catalog/Code_Organization/Form_Objects.yml
+++ b/catalog/Code_Organization/Form_Objects.yml
@@ -2,6 +2,7 @@ name: Form Objects
 description:
 projects:
   - activemodel-form
+  - drg_cms
   - dry-validation
   - reform
   - scrivener


### PR DESCRIPTION
drg_cms gem is much more than CMS. It is the tool for rapid building of in-house (business, intranet, private cloud) applications. Data entry forms generated by DRG Forms define browsing and editing dialog in single YAML file. One DRG Form can contain hundreds of data entry fields and still be easy to maintain and update. Forms can be generated from definition in model files. Generator also creates template for i18n translations. All data entry dialogs are also tightly coupled with data access policies for reading, updating and deleting data.

Thanks for contributing to the Ruby Toolbox catalog! <3

**Before submitting your pull request:**

- [ ] If you're referencing a gem by its GitHub repository (e.g. `rails/rails`), please verify
      that it is _not_ packaged as a Ruby gem. (If it _is_ packaged as a gem, please reference it
      by its gem name instead, e.g. `rails`.)
- [ ] Please make sure the projects are listed in case-insensitive alphabetical order
- [ ] Make sure the CI build passes, we validate your proposed changes in the test suite :)
