### PR TITLE
Add nerd_dice to Math and game_libraries

### DIFF
--- a/catalog/Fun/game_libraries.yml
+++ b/catalog/Fun/game_libraries.yml
@@ -17,6 +17,7 @@ projects:
   - LiteRGSS
   - metro
   - minigl
+  - nerd_dice
   - opengl
   - opengl-bindings
   - opengl-definitions

--- a/catalog/Math_and_Science/Math.yml
+++ b/catalog/Math_and_Science/Math.yml
@@ -4,5 +4,6 @@ projects:
   - continued_fractions
   - integration
   - minimization
+  - nerd_dice
   - nmatrix
   - rb-gsl


### PR DESCRIPTION
Add nerd_dice gem (https://rubygems.org/gems/nerd_dice) to catalog under
the Fun/game_libraries.yml and Math_and_Science/Math.yml categories.

Thanks for contributing to the Ruby Toolbox catalog! <3

**Before submitting your pull request:**

- [ n/a ] If you're referencing a gem by its GitHub repository (e.g. `rails/rails`), please verify
      that it is _not_ packaged as a Ruby gem. (If it _is_ packaged as a gem, please reference it
      by its gem name instead, e.g. `rails`.)
- [ done ] Please make sure the projects are listed in case-insensitive alphabetical order
- [ done ] Make sure the CI build passes, we validate your proposed changes in the test suite :)
