### PR TITLE
Increase permitted length of referenced project name

### DIFF
--- a/json-schema.yml
+++ b/json-schema.yml
@@ -51,4 +51,4 @@ properties:
                 minItems: 1
                 items:
                   type: string
-                  pattern: "^([A-Za-z0-9\\/\\-\\._]{1,50})$"
+                  pattern: "^([A-Za-z0-9\\/\\-\\._]{1,150})$"


### PR DESCRIPTION
Based upon https://github.com/rubytoolbox/catalog/pull/559#issuecomment-859657212

The longest I found has 150, so let's put that