### PR TITLE
Background Processing: Remove beanstalkd

### DIFF
--- a/catalog/Background_Processing/Background_Jobs.yml
+++ b/catalog/Background_Processing/Background_Jobs.yml
@@ -6,6 +6,7 @@ projects:
   - backburner
   - backgrounded
   - barttenbrinke/worker_queue
+  - beaneater
   - beetle
   - bj
   - bunny
@@ -19,7 +20,6 @@ projects:
   - good_job
   - jnstq/job_fu
   - job_reactor
-  - kr/beanstalkd
   - later
   - legionio
   - lowkiq


### PR DESCRIPTION
First things first: Thanks for this amazing project, I've used it so many times ❤️ 

When going through the background job category, I noticed that kr/beanstalkd is high up on the list. However, beanstalkd is not a background processing library, it is a queue implementation (written in C). This would be the equivalent of listing RabbitMQ here. Instead of the queue, we list the Ruby adapters for beanstalkd. backburner was already on the list, adding beaneater.