### PR TITLE
Add alba gem to API Builders

### DIFF
--- a/catalog/Web_Apps_Services_Interaction/API_Builders.yml
+++ b/catalog/Web_Apps_Services_Interaction/API_Builders.yml
@@ -3,6 +3,7 @@ description:
 projects:
   - active_model_serializers
   - acts_as_api
+  - alba
   - api-versions
   - apia
   - apiary


### PR DESCRIPTION
Thanks for contributing to the Ruby Toolbox catalog! <3

**Before submitting your pull request:**

- [ ] If you're referencing a gem by its GitHub repository (e.g. `rails/rails`), please verify
      that it is _not_ packaged as a Ruby gem. (If it _is_ packaged as a gem, please reference it
      by its gem name instead, e.g. `rails`.)
- [ ] Please make sure the projects are listed in case-insensitive alphabetical order
- [ ] Make sure the CI build passes, we validate your proposed changes in the test suite :)
