### PR TITLE
:heavy_plus_sign: zoho_sign to HTTP API Clients

### DIFF
--- a/catalog/HTTP_API_Clients/api_clients.yml
+++ b/catalog/HTTP_API_Clients/api_clients.yml
@@ -87,3 +87,4 @@ projects:
   - youtube_it
   - zabbix-api-simple
   - zeus-api
+  - zoho_sign


### PR DESCRIPTION
https://rubygems.org/gems/zoho_sign
https://github.com/wecasa/zoho_sign

Thanks for contributing to the Ruby Toolbox catalog! <3

**Before submitting your pull request:**

- [x] If you're referencing a gem by its GitHub repository (e.g. `rails/rails`), please verify
      that it is _not_ packaged as a Ruby gem. (If it _is_ packaged as a gem, please reference it
      by its gem name instead, e.g. `rails`.)
- [x] Please make sure the projects are listed in case-insensitive alphabetical order
- [x] Make sure the CI build passes, we validate your proposed changes in the test suite :)
