### PR TITLE
add yalphabetize to Code Metrics

### DIFF
--- a/catalog/Code_Quality/code_metrics.yml
+++ b/catalog/Code_Quality/code_metrics.yml
@@ -31,3 +31,4 @@ projects:
   - snuffle
   - tailor
   - thoughtbot/report_card
+  - yalphabetize


### PR DESCRIPTION
Thanks for contributing to the Ruby Toolbox catalog! <3

**Before submitting your pull request:**

- [x] If you're referencing a gem by its GitHub repository (e.g. `rails/rails`), please verify
      that it is _not_ packaged as a Ruby gem. (If it _is_ packaged as a gem, please reference it
      by its gem name instead, e.g. `rails`.)
- [x] Please make sure the projects are listed in case-insensitive alphabetical order
- [x] Make sure the CI build passes, we validate your proposed changes in the test suite :)
