### PR TITLE
Add dry-rb gems

### DIFF
--- a/catalog/Developer_Tools/Configuration_Management.yml
+++ b/catalog/Developer_Tools/Configuration_Management.yml
@@ -25,6 +25,7 @@ projects:
   - dotconfig
   - dotenv
   - dotenv-rails
+  - dry-configurable
   - dynamic_configuration
   - envied
   - envyable

--- a/catalog/Developer_Tools/scripting_frameworks.yml
+++ b/catalog/Developer_Tools/scripting_frameworks.yml
@@ -2,7 +2,7 @@ name: Scripting Frameworks
 description:  Libraries that simplify the writing of command-line interfaces for your Ruby programs
 projects:
   - boson
-  - hanami-cli
+  - dry-cli
   - lucie
   - main
   - rake

--- a/catalog/Maintenance_Monitoring/rails_instrumentation.yml
+++ b/catalog/Maintenance_Monitoring/rails_instrumentation.yml
@@ -7,6 +7,7 @@ projects:
   - bullet
   - dashing
   - dashing-rails
+  - dry-monitor
   - fnordmetric
   - fozzie
   - fozzie_rails

--- a/catalog/Package_Dependency_Management/dependency_management.yml
+++ b/catalog/Package_Dependency_Management/dependency_management.yml
@@ -8,6 +8,7 @@ projects:
   - bundler
   - checkzilla
   - cutting_edge
+  - dry-system
   - externals
   - gemrat
   - giternal


### PR DESCRIPTION
I added a number of dry-rb.org gems.

I substituted `dry-cli` in for `hanami-cli` because `hanami-cli` was renamed to `dry-cli`.