### PR TITLE
Add enummer to bitfields

### DIFF
--- a/catalog/Active_Record_Plugins/Active_Record_Bit_Fields.yml
+++ b/catalog/Active_Record_Plugins/Active_Record_Bit_Fields.yml
@@ -5,5 +5,6 @@ projects:
   - bitfield_attribute
   - bitfields
   - bitmask_attributes
+  - enummer
   - flag_shih_tzu
   - has-bit-field


### PR DESCRIPTION
Little gem I recently made for this purpose and intend to keep up-to-date. Sort of a "soft"-release right now as I validate it in my own projects. [enummer](https://github.com/shkm/enummer)

Thanks for contributing to the Ruby Toolbox catalog! <3

**Before submitting your pull request:**

- [x] If you're referencing a gem by its GitHub repository (e.g. `rails/rails`), please verify
      that it is _not_ packaged as a Ruby gem. (If it _is_ packaged as a gem, please reference it
      by its gem name instead, e.g. `rails`.)
- [x] Please make sure the projects are listed in case-insensitive alphabetical order
- [x] Make sure the CI build passes, we validate your proposed changes in the test suite :)
