### PR TITLE
Add prosopite gem

### DIFF
--- a/catalog/Maintenance_Monitoring/rails_instrumentation.yml
+++ b/catalog/Maintenance_Monitoring/rails_instrumentation.yml
@@ -17,6 +17,7 @@ projects:
   - newrelic_rpm
   - nunes
   - peek
+  - prosopite
   - rack-bug
   - rack-insight
   - rackamole


### PR DESCRIPTION
Include [prosopite](https://rubygems.org/gems/prosopite) gem to `rails_instrumentation.yml` as it is used to detect N+1 queries.
