### PR TITLE
Add web_translate_it rubygem to the i18n list

### DIFF
--- a/catalog/Time_Space/i18n.yml
+++ b/catalog/Time_Space/i18n.yml
@@ -1,5 +1,5 @@
 name: I18n
-description: 
+description:
 projects:
   - accept_language
   - activerecord_translatable
@@ -48,3 +48,4 @@ projects:
   - to_lang
   - tr8n
   - traduction
+  - web_translate_it


### PR DESCRIPTION
This PR adds the [web_translate_it](https://www.ruby-toolbox.com/projects/web_translate_it) rubygem to the [i18n category](https://www.ruby-toolbox.com/categories/i18n)