### PR TITLE
'jamesotron/Lockbox' repository is gone

### DIFF
--- a/catalog/Security/encryption.yml
+++ b/catalog/Security/encryption.yml
@@ -4,7 +4,6 @@ projects:
   - attr_encrypted
   - crypt_keeper
   - encrypted_strings
-  - jamesotron/Lockbox
   - jmckible/lucifer
   - lockbox
   - miscreant


### PR DESCRIPTION
I looked at issue #7 which discussed the usefulness of abandoned projects. Many of which still work perfectly fine and are also useful for reference.

 However, should projects with no repository be removed?
----------------------------------------------------------
EDIT: Never mind, the project was simply archived. The updated link is https://github.com/jimsynz/Lockbox 

Thanks for contributing to the Ruby Toolbox catalog! <3

**Before submitting your pull request:**

- [X] If you're referencing a gem by its GitHub repository (e.g. `rails/rails`), please verify
      that it is _not_ packaged as a Ruby gem. (If it _is_ packaged as a gem, please reference it
      by its gem name instead, e.g. `rails`.)
- [X] Please make sure the projects are listed in case-insensitive alphabetical order
- [X] Make sure the CI build passes, we validate your proposed changes in the test suite :)
