### PR TITLE
Added debugger category with top debugger projects

### DIFF
--- a/catalog/Developer_Tools/Debuggers.yml
+++ b/catalog/Developer_Tools/Debuggers.yml
@@ -1,0 +1,12 @@
+name: Debuggers
+description: Allow user to view the execution state and data of another application as it's running
+projects:
+  - break
+  - byebug
+  - debase
+  - debugger
+  - google-cloud-debugger
+  - pry-debugger-jruby
+  - pry-nav
+  - pry_debug
+  - ruby-debug-base


### PR DESCRIPTION
bgvo talked about a missing category for byebug in issue #859.

I only included debuggers, excluding comprehensive developer toolsets with debuggers included.

Thanks for contributing to the Ruby Toolbox catalog! <3

**Before submitting your pull request:**

- [X] If you're referencing a gem by its GitHub repository (e.g. `rails/rails`), please verify
      that it is _not_ packaged as a Ruby gem. (If it _is_ packaged as a gem, please reference it
      by its gem name instead, e.g. `rails`.)
- [X] Please make sure the projects are listed in case-insensitive alphabetical order
- [X] Make sure the CI build passes, we validate your proposed changes in the test suite :)
