### PR TITLE
Add fast_excel to Reports & Spreadsheets

### DIFF
--- a/catalog/Documents_Reports/reporting.yml
+++ b/catalog/Documents_Reports/reporting.yml
@@ -12,6 +12,7 @@ projects:
   - dossier
   - dynamic_reports
   - excel_rails
+  - fast_excel
   - gnumeric
   - goffice
   - google-spreadsheet-ruby


### PR DESCRIPTION
Thanks for contributing to the Ruby Toolbox catalog! <3

**Before submitting your pull request:**

- [x] If you're referencing a gem by its GitHub repository (e.g. `rails/rails`), please verify
      that it is _not_ packaged as a Ruby gem. (If it _is_ packaged as a gem, please reference it
      by its gem name instead, e.g. `rails`.)
- [x] Please make sure the projects are listed in case-insensitive alphabetical order
- [ ] Make sure the CI build passes, we validate your proposed changes in the test suite :)



I noticed `fast_excel` was missing from the list ^^