### PR TITLE
Update GUI Frameworks

### DIFF
--- a/catalog/Developer_Tools/GUI_Frameworks.yml
+++ b/catalog/Developer_Tools/GUI_Frameworks.yml
@@ -8,9 +8,9 @@ projects:
   - glimmer-dsl-libui
   - glimmer-dsl-swt
   - glimmer-dsl-tk
-  - gtk2
   - gtk3
   - libui
   - qtbindings
   - shoes
+  - tk
   - wxruby


### PR DESCRIPTION
* Added tk
* Removed gtk2

- [x] If you're referencing a gem by its GitHub repository (e.g. `rails/rails`), please verify
      that it is _not_ packaged as a Ruby gem. (If it _is_ packaged as a gem, please reference it
      by its gem name instead, e.g. `rails`.)
- [x] Please make sure the projects are listed in case-insensitive alphabetical order
- [ ] Make sure the CI build passes, we validate your proposed changes in the test suite :)
