### PR TITLE
Statesman to the State machines category

### DIFF
--- a/catalog/Rails_Plugins/state_machines.yml
+++ b/catalog/Rails_Plugins/state_machines.yml
@@ -7,7 +7,6 @@ projects:
   - golem_statemachine
   - micromachine
   - ruote
-  - statesman
   - simple_state_machine
   - simple_states
   - stamina
@@ -16,6 +15,7 @@ projects:
   - state_machines
   - state_objects
   - stateflow
+  - statesman
   - status-manager
   - transitions
   - workflow

--- a/catalog/Rails_Plugins/state_machines.yml
+++ b/catalog/Rails_Plugins/state_machines.yml
@@ -7,6 +7,7 @@ projects:
   - golem_statemachine
   - micromachine
   - ruote
+  - statesman
   - simple_state_machine
   - simple_states
   - stamina


### PR DESCRIPTION
Added statesman gem to the state machines category

Thanks for contributing to the Ruby Toolbox catalog! <3

**Before submitting your pull request:**

- [x] If you're referencing a gem by its GitHub repository (e.g. `rails/rails`), please verify
      that it is _not_ packaged as a Ruby gem. (If it _is_ packaged as a gem, please reference it
      by its gem name instead, e.g. `rails`.)
- [x] Please make sure the projects are listed in case-insensitive alphabetical order
- [ ] Make sure the CI build passes, we validate your proposed changes in the test suite :)
