### PR TITLE
Add Rails Tours category with abraham gem

### DIFF
--- a/catalog/Active_Record_Plugins/rails_tours.yml
+++ b/catalog/Active_Record_Plugins/rails_tours.yml
@@ -1,0 +1,4 @@
+name: Rails Tours
+description: Utilities to provided guided tours of the application
+projects:
+  - abraham


### PR DESCRIPTION
Wanted to list [abraham](https://github.com/actmd/abraham) gem in the catalog. Since this is a tour gem that relies on ActiveRecord, couldn't find an appropriate category for it. So created one!

Thanks for contributing to the Ruby Toolbox catalog! <3

**Before submitting your pull request:**

- [x] If you're referencing a gem by its GitHub repository (e.g. `rails/rails`), please verify
      that it is _not_ packaged as a Ruby gem. (If it _is_ packaged as a gem, please reference it
      by its gem name instead, e.g. `rails`.)
- [x] Please make sure the projects are listed in case-insensitive alphabetical order
- [x] Make sure the CI build passes, we validate your proposed changes in the test suite :)
