### PR TITLE
Add ransack & search_cop to Rails Search category

### DIFF
--- a/catalog/Active_Record_Plugins/rails_search.yml
+++ b/catalog/Active_Record_Plugins/rails_search.yml
@@ -13,10 +13,12 @@ projects:
   - elastictastic
   - ferret
   - pg_search
+  - ransack
   - redis-search
   - rsolr
   - ruby_simple_search
   - scoped_search
+  - search_cop
   - searchkick
   - searchlight
   - slingshot-rb


### PR DESCRIPTION
Thanks for contributing to the Ruby Toolbox catalog! <3

**Before submitting your pull request:**

- [x] If you're referencing a gem by its GitHub repository (e.g. `rails/rails`), please verify
      that it is _not_ packaged as a Ruby gem. (If it _is_ packaged as a gem, please reference it
      by its gem name instead, e.g. `rails`.)
- [x] Please make sure the projects are listed in case-insensitive alphabetical order
- [x] Make sure the CI build passes, we validate your proposed changes in the test suite :)
