### PR TITLE
add gel

### DIFF
--- a/catalog/Package_Dependency_Management/dependency_management.yml
+++ b/catalog/Package_Dependency_Management/dependency_management.yml
@@ -9,6 +9,7 @@ projects:
   - checkzilla
   - cutting_edge
   - externals
+  - gel
   - gemrat
   - giternal
   - halorgium/gem_resolver


### PR DESCRIPTION
- https://github.com/gel-rb/gel
- A modern gem manager: Gel is a lightweight alternative to Bundler
