### PR TITLE
Standard gem is missing in the Code Quality catalog

### DIFF
--- a/catalog/Code_Quality/code_metrics.yml
+++ b/catalog/Code_Quality/code_metrics.yml
@@ -29,5 +29,6 @@ projects:
   - sandi_meter
   - skunk
   - snuffle
+  - standard
   - tailor
   - thoughtbot/report_card


### PR DESCRIPTION
Repo: https://github.com/testdouble/standard
Lightning talk on Rubyconf LA 2018: https://www.youtube.com/watch?v=uLyV5hOqGQ8

Thanks for contributing to the Ruby Toolbox catalog! <3

**Before submitting your pull request:**

- [x] If you're referencing a gem by its GitHub repository (e.g. `rails/rails`), please verify
      that it is _not_ packaged as a Ruby gem. (If it _is_ packaged as a gem, please reference it
      by its gem name instead, e.g. `rails`.)
- [x] Please make sure the projects are listed in case-insensitive alphabetical order
- [x] Make sure the CI build passes, we validate your proposed changes in the test suite :)
