### PR TITLE
Add new category Business application development and add drg_cms to it

### DIFF
--- a/catalog/Business_Application_Development/application_generators.yml
+++ b/catalog/Business_Application_Development/application_generators.yml
@@ -1,0 +1,4 @@
+name: Application Generators
+description: 
+projects:
+  - drg_cms

--- a/catalog/Business_Application_Development/application_generators.yml
+++ b/catalog/Business_Application_Development/application_generators.yml
@@ -1,4 +1,0 @@
-name: Application Generators
-description: 
-projects:
-  - drg_cms

--- a/catalog/Business_Apps_Development/_meta.yml
+++ b/catalog/Business_Apps_Development/_meta.yml
@@ -1,0 +1,1 @@
+name: Business Application Development

--- a/catalog/Business_Apps_Development/application_generators.yml
+++ b/catalog/Business_Apps_Development/application_generators.yml
@@ -1,0 +1,4 @@
+name: Application Generators
+description: 
+projects:
+  - drg_cms


### PR DESCRIPTION
Ruby is perfect tool for building business applications. drg_cms gem is an example of tools that can be used for rapid development of such applications.

Since you already stand it in our prior conversations that drg_cms can not be categorized in any other category I am proposing this new category to Ruby Toolbox.

by
TheR