### PR TITLE
add `hoardable` to ActiveRecord versioning and soft-deletion

### DIFF
--- a/catalog/Active_Record_Plugins/Active_Record_Soft_Delete.yml
+++ b/catalog/Active_Record_Plugins/Active_Record_Soft_Delete.yml
@@ -7,6 +7,7 @@ projects:
   - destroyed_at
   - discard
   - expectedbehavior/acts_as_archival
+  - hoardable
   - immortal
   - paper_trail
   - paranoia

--- a/catalog/Active_Record_Plugins/Active_Record_Versioning.yml
+++ b/catalog/Active_Record_Plugins/Active_Record_Versioning.yml
@@ -10,6 +10,7 @@ projects:
   - changeling
   - has_draft
   - historical
+  - hoardable
   - logidze
   - paper_trail
   - record_history


### PR DESCRIPTION
Hoardable is a fairly new versioning and soft-deletion gem for ActiveRecord and Postgres that uses uni-temporal inherited tables to implement its features.

---

Thanks for contributing to the Ruby Toolbox catalog! <3

**Before submitting your pull request:**

- [x] If you're referencing a gem by its GitHub repository (e.g. `rails/rails`), please verify
      that it is _not_ packaged as a Ruby gem. (If it _is_ packaged as a gem, please reference it
      by its gem name instead, e.g. `rails`.)
- [x] Please make sure the projects are listed in case-insensitive alphabetical order
- [x] Make sure the CI build passes, we validate your proposed changes in the test suite :)
