### PR TITLE
Add the fork of blueprinter

### DIFF
--- a/catalog/Web_Apps_Services_Interaction/API_Builders.yml
+++ b/catalog/Web_Apps_Services_Interaction/API_Builders.yml
@@ -9,6 +9,7 @@ projects:
   - apiary
   - bldr
   - blueprinter
+  - blueprinter-rb
   - cache_crispies
   - fast_jsonapi
   - grape


### PR DESCRIPTION
Given the blueprinter gem isn't getting any attention and the maintainers are completely unresponsive, one person is trying to keep this gem alive so let's add that fork.

See more on https://github.com/procore/blueprinter/issues/288#issuecomment-1313926802

**Before submitting your pull request:**

- [x] If you're referencing a gem by its GitHub repository (e.g. `rails/rails`), please verify
      that it is _not_ packaged as a Ruby gem. (If it _is_ packaged as a gem, please reference it
      by its gem name instead, e.g. `rails`.)
- [x] Please make sure the projects are listed in case-insensitive alphabetical order
- [x] Make sure the CI build passes, we validate your proposed changes in the test suite :)
