### PR TITLE
Add unleash to the list of A/B test gems

### DIFF
--- a/catalog/Testing/A_B_Testing.yml
+++ b/catalog/Testing/A_B_Testing.yml
@@ -11,5 +11,6 @@ projects:
   - fluidfeatures-rails
   - paulmars/seven_minute_abs
   - split
+  - unleash
   - validation_issues
   - vanity


### PR DESCRIPTION
Thanks for contributing to the Ruby Toolbox catalog! <3

**Before submitting your pull request:**

- [ ] ~~If you're referencing a gem by its GitHub repository (e.g. `rails/rails`), please verify
      that it is _not_ packaged as a Ruby gem. (If it _is_ packaged as a gem, please reference it
      by its gem name instead, e.g. `rails`.)~~
- [x] Please make sure the projects are listed in case-insensitive alphabetical order
- [ ] Make sure the CI build passes, we validate your proposed changes in the test suite :)
