### PR TITLE
Add minitest-substitute to mocking.yml

### DIFF
--- a/catalog/Testing/mocking.yml
+++ b/catalog/Testing/mocking.yml
@@ -6,6 +6,7 @@ projects:
   - facon
   - flexmock
   - jm/stump
+  - minitest-substitute
   - mocha
   - mock_redis
   - mocoso


### PR DESCRIPTION
Simple Minitest helper to replace values such as an instance variable of an object or an environment variable for the duration of a block or a group of tests. This comes in very handy when you have to derive from default configuration in order to test some aspects of your code.

Thanks for contributing to the Ruby Toolbox catalog! <3

**Before submitting your pull request:**

- [x] If you're referencing a gem by its GitHub repository (e.g. `rails/rails`), please verify
      that it is _not_ packaged as a Ruby gem. (If it _is_ packaged as a gem, please reference it
      by its gem name instead, e.g. `rails`.)
- [x] Please make sure the projects are listed in case-insensitive alphabetical order
- [x] Make sure the CI build passes, we validate your proposed changes in the test suite :)
