### PR TITLE
Add sassc and sass-embedded to CSS Tools

### DIFF
--- a/catalog/CSS/css_with_ruby.yml
+++ b/catalog/CSS/css_with_ruby.yml
@@ -9,6 +9,9 @@ projects:
   - patterns
   - rainpress
   - sass
+  - sass-embedded
   - sass-rails
+  - sassc
+  - sassc-rails
   - smurfville
   - stylus


### PR DESCRIPTION
This PR adds modern Sass implementations:

- The original ruby `sass` has reached end of life as of 26 March 2019. 
- `sassc` was the second implementation, and it has been deprecated and will reach end of life soon.
- `sass-embedded` is the latest implementation that is built on top of `dart-sass`.


**Before submitting your pull request:**

- [x] If you're referencing a gem by its GitHub repository (e.g. `rails/rails`), please verify
      that it is _not_ packaged as a Ruby gem. (If it _is_ packaged as a gem, please reference it
      by its gem name instead, e.g. `rails`.)
- [x] Please make sure the projects are listed in case-insensitive alphabetical order
- [x] Make sure the CI build passes, we validate your proposed changes in the test suite :)
