### PR TITLE
Add rack-dedos to security tools

### DIFF
--- a/catalog/Security/security_tools.yml
+++ b/catalog/Security/security_tools.yml
@@ -10,6 +10,7 @@ projects:
   - look/xss_terminate
   - mhartl/find_mass_assignment
   - param_protected
+  - rack-dedos
   - rails_xss
   - ryanlowe/audit_mass_assignment
   - shellex


### PR DESCRIPTION
Thanks for contributing to the Ruby Toolbox catalog! <3

**Before submitting your pull request:**

- [x] If you're referencing a gem by its GitHub repository (e.g. `rails/rails`), please verify
      that it is _not_ packaged as a Ruby gem. (If it _is_ packaged as a gem, please reference it
      by its gem name instead, e.g. `rails`.)
- [x] Please make sure the projects are listed in case-insensitive alphabetical order
- [x] Make sure the CI build passes, we validate your proposed changes in the test suite :)
