### PR TITLE
Add magvar gem

### DIFF
--- a/catalog/Math_and_Science/Aeronautics.yml
+++ b/catalog/Math_and_Science/Aeronautics.yml
@@ -6,6 +6,7 @@ projects:
   - aixm
   - fdc
   - flight
+  - magvar
   - notam
   - ogn_client-ruby
   - vfr_utils


### PR DESCRIPTION
helps with calculating magnetic variation using the open FlightGear model. The model is known to also be used by the X-Plane flight simulator.

Thanks for contributing to the Ruby Toolbox catalog! <3

**Before submitting your pull request:**

- [x] If you're referencing a gem by its GitHub repository (e.g. `rails/rails`), please verify
      that it is _not_ packaged as a Ruby gem. (If it _is_ packaged as a gem, please reference it
      by its gem name instead, e.g. `rails`.)
- [x] Please make sure the projects are listed in case-insensitive alphabetical order
- [ ] Make sure the CI build passes, we validate your proposed changes in the test suite :)
