### PR TITLE
Logging: add some of the most popular gems

### DIFF
--- a/catalog/Maintenance_Monitoring/Logging.yml
+++ b/catalog/Maintenance_Monitoring/Logging.yml
@@ -4,23 +4,32 @@ projects:
   - best_boy
   - cabin
   - clogger
+  - contextual_logger
+  - dry-logger
+  - fluent-logger
   - fluentd
   - frogger
   - gelf
   - hatchet
+  - http_logger
   - httplog
   - justlogging-rails
   - log4r
+  - logger
   - logging
   - logging-rails
   - logging_assist
   - lograge
+  - logstash-logger
   - lumber
   - mongodb_logger
+  - mono_logger
   - ougai
   - rails-pretty-logger
+  - rails_semantic_logger
   - rake_bubbler
   - semantic_logger
   - sentry-raven
+  - syslog-logger
   - whoops
   - yell


### PR DESCRIPTION
- [x] If you're referencing a gem by its GitHub repository (e.g. `rails/rails`), please verify
      that it is _not_ packaged as a Ruby gem. (If it _is_ packaged as a gem, please reference it
      by its gem name instead, e.g. `rails`.)
- [x] Please make sure the projects are listed in case-insensitive alphabetical order
- [x] Make sure the CI build passes, we validate your proposed changes in the test suite :)
