### PR TITLE
Add Filterameter gem to Rails Search category

### DIFF
--- a/catalog/Active_Record_Plugins/rails_search.yml
+++ b/catalog/Active_Record_Plugins/rails_search.yml
@@ -12,6 +12,7 @@ projects:
   - elasticsearch-rails
   - elastictastic
   - ferret
+  - filterameter
   - forty_facets
   - pg_search
   - ransack


### PR DESCRIPTION
This gem enables filter parameters to be declared in query classes or controlllers.

https://rubygems.org/gems/filterameter

Thanks for contributing to the Ruby Toolbox catalog! <3

**Before submitting your pull request:**

- N/A If you're referencing a gem by its GitHub repository (e.g. `rails/rails`), please verify
      that it is _not_ packaged as a Ruby gem. (If it _is_ packaged as a gem, please reference it
      by its gem name instead, e.g. `rails`.)
- [x] Please make sure the projects are listed in case-insensitive alphabetical order
- [ ] Make sure the CI build passes, we validate your proposed changes in the test suite :)
