### PR TITLE
Add OXML to XML parsers/builders

### DIFF
--- a/catalog/Web_Apps_Services_Interaction/xml_mapping.yml
+++ b/catalog/Web_Apps_Services_Interaction/xml_mapping.yml
@@ -8,6 +8,7 @@ projects:
   - nokogiri-happymapper
   - nori
   - ox
+  - oxml
   - representative
   - rexml
   - roxml


### PR DESCRIPTION
Hello and thank you for maintaining the Ruby Toolbox! 🎉 

I have recently developed an XML parser/builder with improved performance for commercial purposes, but now I have a chance to share it with the community. I often use your catalog for development and thought it might be a good idea to spread the word about the [OXML](https://github.com/xkwd/oxml) gem here. I hope this is appropriate and would appreciate your approval 🙂 Thanks!

**Before submitting your pull request:**

- [x] If you're referencing a gem by its GitHub repository (e.g. `rails/rails`), please verify
      that it is _not_ packaged as a Ruby gem. (If it _is_ packaged as a gem, please reference it
      by its gem name instead, e.g. `rails`.)
- [x] Please make sure the projects are listed in case-insensitive alphabetical order
- [x] Make sure the CI build passes, we validate your proposed changes in the test suite :)
