### PR TITLE
remove mongoid-raiting (gem removed by owner)

### DIFF
--- a/catalog/Active_Record_Plugins/rails_ratings.yml
+++ b/catalog/Active_Record_Plugins/rails_ratings.yml
@@ -7,6 +7,5 @@ projects:
   - edgarjs/ajaxful-rating
   - has_ratings
   - letsrate
-  - mongoid-rating
   - mongoid_rateable
   - zachinglis/is_rateable


### PR DESCRIPTION
https://rubygems.org/gems/mongoid-rating

"This gem previously existed, but has been removed by its owner"

Thanks for contributing to the Ruby Toolbox catalog! <3

**Before submitting your pull request:**

- [x ] If you're referencing a gem by its GitHub repository (e.g. `rails/rails`), please verify
      that it is _not_ packaged as a Ruby gem. (If it _is_ packaged as a gem, please reference it
      by its gem name instead, e.g. `rails`.)
- [ x] Please make sure the projects are listed in case-insensitive alphabetical order
- [ x] Make sure the CI build passes, we validate your proposed changes in the test suite :)
