### PR TITLE
Remove PaperTrail from Active_Record_Soft_Delete.yml

### DIFF
--- a/catalog/Active_Record_Plugins/Active_Record_Soft_Delete.yml
+++ b/catalog/Active_Record_Plugins/Active_Record_Soft_Delete.yml
@@ -9,7 +9,6 @@ projects:
   - expectedbehavior/acts_as_archival
   - hoardable
   - immortal
-  - paper_trail
   - paranoia
   - paranoid
   - paranoid2


### PR DESCRIPTION
I don't think of PaperTrail as implementing soft-deletion. In my mind, soft-deletion is a way of marking a record as deleted, without actually deleting it from the db table. PaperTrail has no such feature.

By contrast, PaperTrail is already correctly listed under https://www.ruby-toolbox.com/categories/Active_Record_Versioning