### PR TITLE
Add `phlex` to the "HTML Markup" category

### DIFF
--- a/catalog/HTML_Markup/template_engines.yml
+++ b/catalog/HTML_Markup/template_engines.yml
@@ -22,6 +22,7 @@ projects:
   - markerb
   - mustache
   - PageTemplate
+  - phlex
   - pug-ruby
   - ruty
   - scottpersinger/laminate


### PR DESCRIPTION
This pull request adds [`phlex`](https://phlex.fun) to the HTML Markup category.

**Before submitting your pull request:**

- [x] If you're referencing a gem by its GitHub repository (e.g. `rails/rails`), please verify
      that it is _not_ packaged as a Ruby gem. (If it _is_ packaged as a gem, please reference it
      by its gem name instead, e.g. `rails`.)
- [x] Please make sure the projects are listed in case-insensitive alphabetical order
- [ ] Make sure the CI build passes, we validate your proposed changes in the test suite :)
