### PR TITLE
CLI_option_Parsers: add subcommand

### DIFF
--- a/catalog/Developer_Tools/CLI_Option_Parsers.yml
+++ b/catalog/Developer_Tools/CLI_Option_Parsers.yml
@@ -42,6 +42,7 @@ projects:
   - samovar
   - slop
   - sod
+  - subcommand
   - terrapin
   - trollop
   - tty-option


### PR DESCRIPTION
Thanks for contributing to the Ruby Toolbox catalog! <3

**Before submitting your pull request:**

- [x] If you're referencing a gem by its GitHub repository (e.g. `rails/rails`), please verify
      that it is _not_ packaged as a Ruby gem. (If it _is_ packaged as a gem, please reference it
      by its gem name instead, e.g. `rails`.)
- [x] Please make sure the projects are listed in case-insensitive alphabetical order
- [x] Make sure the CI build passes, we validate your proposed changes in the test suite :)

---

old (14 years), have been maintained for 12+ years until 2 years ago, add support for sub-commands to default OptionParser

- https://rubygems.org/gems/subcommand
- https://github.com/rkumar/subcommand