### PR TITLE
CLI_Option_Parsers: add dencli

### DIFF
--- a/catalog/Developer_Tools/CLI_Option_Parsers.yml
+++ b/catalog/Developer_Tools/CLI_Option_Parsers.yml
@@ -19,6 +19,7 @@ projects:
   - config_parser
   - cri
   - cyclops
+  - dencli
   - docopt
   - docopt-compgen
   - dry-cli


### PR DESCRIPTION
Thanks for contributing to the Ruby Toolbox catalog! <3

**Before submitting your pull request:**

- [x] If you're referencing a gem by its GitHub repository (e.g. `rails/rails`), please verify
      that it is _not_ packaged as a Ruby gem. (If it _is_ packaged as a gem, please reference it
      by its gem name instead, e.g. `rails`.)
- [x] Please make sure the projects are listed in case-insensitive alphabetical order
- [x] Make sure the CI build passes, we validate your proposed changes in the test suite :)

---

- https://rubygems.org/gems/dencli
- https://git.denkn.at/deac/dencli