### PR TITLE
Add rails_i18n_manager to i18n section

### DIFF
--- a/catalog/Time_Space/i18n.yml
+++ b/catalog/Time_Space/i18n.yml
@@ -39,6 +39,7 @@ projects:
   - rack-user-locale
   - rails-i18nterface
   - rails-translate-models
+  - rails_i18n_manager
   - rails_locale_detection
   - raul/translate_routes
   - ready_for_i18n


### PR DESCRIPTION
Thanks for contributing to the Ruby Toolbox catalog! <3

**Before submitting your pull request:**

- [x] If you're referencing a gem by its GitHub repository (e.g. `rails/rails`), please verify
      that it is _not_ packaged as a Ruby gem. (If it _is_ packaged as a gem, please reference it
      by its gem name instead, e.g. `rails`.)
- [x] Please make sure the projects are listed in case-insensitive alphabetical order
- [x] Make sure the CI build passes, we validate your proposed changes in the test suite :)

Github URL: https://github.com/westonganger/rails_i18n_manager