### PR TITLE
Loosen ordering requirement, add seedie

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -5,5 +5,4 @@ Thanks for contributing to the Ruby Toolbox catalog! <3
 - [ ] If you're referencing a gem by its GitHub repository (e.g. `rails/rails`), please verify
       that it is _not_ packaged as a Ruby gem. (If it _is_ packaged as a gem, please reference it
       by its gem name instead, e.g. `rails`.)
-- [ ] Please make sure the projects are listed in case-insensitive alphabetical order
 - [ ] Make sure the CI build passes, we validate your proposed changes in the test suite :)

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Each `category.yml` currently contains:
 
 * `name` (string, required): Human display name of the category name
 * `description` (string, optional): A (markdown-formatted) category description
-* `projects` (array of strings in case-insensitive alphabetical order, required): The list of projects to list in
+* `projects` (array of strings, required): The list of projects to list in
   that category. For rubygems, this is the plain gem name, for github repos it's
   the full repo slug (`github_user/repo_name`). Projects can be listed in multiple
   categories.

--- a/catalog/Active_Record_Plugins/rails_db_bootstrapping.yml
+++ b/catalog/Active_Record_Plugins/rails_db_bootstrapping.yml
@@ -8,4 +8,5 @@ projects:
   - seed-fu
   - seed_dumper
   - seedbank
+  - seedie
   - sevenwire/bootstrapper

--- a/spec/catalog_spec.rb
+++ b/spec/catalog_spec.rb
@@ -29,9 +29,8 @@ RSpec.describe Catalog do
 
   described_class.new.as_json[:category_groups].map { |group| group[:categories] }.flatten.each do |category|
     describe "Category #{category['name'].inspect}" do
-      it "defines all projects in alphabetical order" do
-        expected_order = category["projects"].sort_by(&:downcase)
-        expect(category["projects"]).to eq expected_order
+      it "does not define duplicates" do
+        expect(category["projects"]).to eq category["projects"].uniq
       end
     end
   end


### PR DESCRIPTION
Followup to https://github.com/rubytoolbox/catalog/pull/867 as I was not allowed to update that PR in place.

Also, this removes the sorting order restriction, it gives too much trouble mopping this up again for dubious benefit, in the end it doesn't really matter as long as projects are unique (which we do check now) per category