### PR TITLE
Add `evil-seed` to Rails DB Bootstrapping category

### DIFF
--- a/catalog/Active_Record_Plugins/rails_db_bootstrapping.yml
+++ b/catalog/Active_Record_Plugins/rails_db_bootstrapping.yml
@@ -2,6 +2,7 @@ name: Rails DB Bootstrapping
 description: Easily insert and maintain seed data in the database.
 projects:
   - dibber
+  - evil-seed
   - ffmike/db-populate
   - has_alter_ego
   - populator


### PR DESCRIPTION
Include [evil-seed](https://rubygems.org/gems/evil-seed) gem to Rails DB Bootstrapping category as it is used for that purpose