### PR TITLE
Add `shopify-money` to Money, Currencies, Exchange Rates category

### DIFF
--- a/catalog/E-Commerce_and_Payments/Money_Currencies.yml
+++ b/catalog/E-Commerce_and_Payments/Money_Currencies.yml
@@ -7,3 +7,4 @@ projects:
   - money
   - money-currencylayer-bank
   - money-openexchangerates-bank
+  - shopify-money


### PR DESCRIPTION
Include [shopify-money](https://rubygems.org/gems/shopify-money) gem to Money, Currencies, Exchange Rates category as it is used for that purpose