### PR TITLE
Create a Surveys and Questioneers Category

### DIFF
--- a/catalog/Active_Record_Plugins/rails_surveys_and_questioneers.yml
+++ b/catalog/Active_Record_Plugins/rails_surveys_and_questioneers.yml
@@ -1,0 +1,8 @@
+name: Rails Surveys and Questioneers 
+description: Easily add surveys, polls, and questionnaires to your Rails app.
+projects:
+  - questionnaire_engine 
+  - surveyor
+  - survey
+  - rapidfire
+  - tadpoll


### PR DESCRIPTION
Seemed like a category for Survey, Polls, and Questioneers functionality for rails was missing. Let me know if you think it would be useful to include.

- [X] All references point to gem names
- [ ] Make sure the CI build passes, we validate your proposed changes in the test suite :)
