### PR TITLE
Add more gems to api builders

### DIFF
--- a/catalog/Web_Apps_Services_Interaction/API_Builders.yml
+++ b/catalog/Web_Apps_Services_Interaction/API_Builders.yml
@@ -17,6 +17,9 @@ projects:
   - grapethor
   - jb
   - jbuilder
+  - jsonapi-hanami
+  - jsonapi-rails
+  - jsonapi-ruby
   - jsonapi-serializer
   - mutils
   - nativeson


### PR DESCRIPTION
Thanks for contributing to the Ruby Toolbox catalog! <3

**Before submitting your pull request:**

- [x] If you're referencing a gem by its GitHub repository (e.g. `rails/rails`), please verify
      that it is _not_ packaged as a Ruby gem. (If it _is_ packaged as a gem, please reference it
      by its gem name instead, e.g. `rails`.)
- [x] Make sure the CI build passes, we validate your proposed changes in the test suite :)
