### PR TITLE
Add nokolexbor to HTML parsing

### DIFF
--- a/catalog/Web_Apps_Services_Interaction/html_parsing.yml
+++ b/catalog/Web_Apps_Services_Interaction/html_parsing.yml
@@ -5,6 +5,7 @@ projects:
   - libxml-ruby
   - nikkou
   - nokogiri
+  - nokolexbor
   - oga
   - ox
   - rubyful_soup


### PR DESCRIPTION
Thanks for contributing to the Ruby Toolbox catalog! <3

I like that it's faster and has a smaller memory footprint than Nokogiri, at least in my use cases :)
Also, I don't have to wait for eternity for it to compile on Raspberry Pi.

**Before submitting your pull request:**

- [x] If you're referencing a gem by its GitHub repository (e.g. `rails/rails`), please verify
      that it is _not_ packaged as a Ruby gem. (If it _is_ packaged as a gem, please reference it
      by its gem name instead, e.g. `rails`.)
- [x] Make sure the CI build passes, we validate your proposed changes in the test suite :)
