### PR TITLE
Add `darkroom` to the Asset Management category

### DIFF
--- a/catalog/Provision_Deploy_Host/Asset_Management.yml
+++ b/catalog/Provision_Deploy_Host/Asset_Management.yml
@@ -6,6 +6,7 @@ projects:
   - asset_packager
   - cornflakesuperstar/minified_cache
   - css_splitter
+  - darkroom
   - half-pipe
   - jammit
   - raptest


### PR DESCRIPTION
Thanks for contributing to the Ruby Toolbox catalog! <3

**Before submitting your pull request:**

- [X] If you're referencing a gem by its GitHub repository (e.g. `rails/rails`), please verify
      that it is _not_ packaged as a Ruby gem. (If it _is_ packaged as a gem, please reference it
      by its gem name instead, e.g. `rails`.)
- [ ] Make sure the CI build passes, we validate your proposed changes in the test suite :)
