### PR TITLE
Add Nero

### DIFF
--- a/catalog/Developer_Tools/Configuration_Management.yml
+++ b/catalog/Developer_Tools/Configuration_Management.yml
@@ -38,6 +38,7 @@ projects:
   - informante
   - ledermann-rails-settings
   - micon
+  - nero
   - optimism
   - rails-settings
   - rails_config


### PR DESCRIPTION
Add [nero](https://github.com/eval/nero) to Configuration Management category

Thanks for contributing to the Ruby Toolbox catalog! <3

**Before submitting your pull request:**

- [ ] If you're referencing a gem by its GitHub repository (e.g. `rails/rails`), please verify
      that it is _not_ packaged as a Ruby gem. (If it _is_ packaged as a gem, please reference it
      by its gem name instead, e.g. `rails`.)
- [ ] Make sure the CI build passes, we validate your proposed changes in the test suite :)
