### PR TITLE
Add NextPage gem to Pagination category

### DIFF
--- a/catalog/Active_Record_Plugins/pagination.yml
+++ b/catalog/Active_Record_Plugins/pagination.yml
@@ -5,6 +5,7 @@ projects:
   - geared_pagination
   - kaminari
   - kaminari-bootstrap
+  - next_page
   - nexter
   - order_query
   - paged_scopes


### PR DESCRIPTION
Thanks for contributing to the Ruby Toolbox catalog! <3

**Before submitting your pull request:**

- [X] If you're referencing a gem by its GitHub repository (e.g. `rails/rails`), please verify
      that it is _not_ packaged as a Ruby gem. (If it _is_ packaged as a gem, please reference it
      by its gem name instead, e.g. `rails`.)
- [ ] Make sure the CI build passes, we validate your proposed changes in the test suite :)
