### PR TITLE
Add active_record_compose to form objects

### DIFF
--- a/catalog/Code_Organization/Form_Objects.yml
+++ b/catalog/Code_Organization/Form_Objects.yml
@@ -1,6 +1,7 @@
 name: Form Objects
 description:
 projects:
+  - active_record_compose
   - activemodel-form
   - dry-validation
   - reform


### PR DESCRIPTION
I'd like to add `active_record_compose` to the "Form Objects" category.
It is a Ruby gem that provides a simple way to compose form objects on top of ActiveRecord models.
The gem is published on RubyGems and is actively maintained.

Thanks for your consideration!