### PR TITLE
Add dry-operation to Service Objects catalog

### DIFF
--- a/catalog/Code_Organization/Service_Objects.yml
+++ b/catalog/Code_Organization/Service_Objects.yml
@@ -3,6 +3,7 @@ description: Libraries to isolate application domain logic into separate classes
 projects:
   - active_interaction
   - civil_service
+  - dry-operation
   - dry-transaction
   - interactor
   - light-service


### PR DESCRIPTION
Add dry-operation to the "Service Objects" catalog.

dry-operation is our successor to dry-transaction (which I'm still keeping here, since it still works fine, and because we haven't quite finished documenting a proper transition path). It is included by default in new Hanami apps (v2.2 and later).