### PR TITLE
Add Securial to Security > Rails Authentication

### DIFF
--- a/catalog/Security/rails_authentication.yml
+++ b/catalog/Security/rails_authentication.yml
@@ -21,6 +21,7 @@ projects:
   - rodauth
   - rodauth-oauth
   - rpx_now
+  - securial
   - sorcery
   - switch_user
   - technoweenie/restful-authentication


### PR DESCRIPTION
Thanks for contributing to the Ruby Toolbox catalog! <3

**Before submitting your pull request:**

- [ ] If you're referencing a gem by its GitHub repository (e.g. `rails/rails`), please verify
      that it is _not_ packaged as a Ruby gem. (If it _is_ packaged as a gem, please reference it
      by its gem name instead, e.g. `rails`.)
- [ ] Make sure the CI build passes, we validate your proposed changes in the test suite :)
