### PR TITLE
Add rspec-stubbed_env to mocking.yml

### DIFF
--- a/catalog/Testing/mocking.yml
+++ b/catalog/Testing/mocking.yml
@@ -12,6 +12,7 @@ projects:
   - mocoso
   - rr
   - rspec-mocks
+  - rspec-stubbed_env
   - simple_mock
   - spy
   - surrogate


### PR DESCRIPTION
Thanks for contributing to the Ruby Toolbox catalog! <3

**Before submitting your pull request:**

- [x] If you're referencing a gem by its GitHub repository (e.g. `rails/rails`), please verify
      that it is _not_ packaged as a Ruby gem. (If it _is_ packaged as a gem, please reference it
      by its gem name instead, e.g. `rails`.)
- [x] Make sure the CI build passes, we validate your proposed changes in the test suite :)
