### PR TITLE
Add gemstash as a gem hosting gem

### DIFF
--- a/catalog/Package_Dependency_Management/Gem_Hosting.yml
+++ b/catalog/Package_Dependency_Management/Gem_Hosting.yml
@@ -3,4 +3,5 @@ description:
 projects:
   - gemfury
   - geminabox
+  - gemstash
   - stickler


### PR DESCRIPTION
Thanks for contributing to the Ruby Toolbox catalog! <3

**Before submitting your pull request:**

- [X] If you're referencing a gem by its GitHub repository (e.g. `rails/rails`), please verify
      that it is _not_ packaged as a Ruby gem. (If it _is_ packaged as a gem, please reference it
      by its gem name instead, e.g. `rails`.)
- [ ] Make sure the CI build passes, we validate your proposed changes in the test suite :)
