### PR TITLE
Add RubyShell to Scripting Frameworks Catalog

### DIFF
--- a/catalog/Developer_Tools/scripting_frameworks.yml
+++ b/catalog/Developer_Tools/scripting_frameworks.yml
@@ -7,5 +7,7 @@ projects:
   - lucie
   - main
   - rake
+  - rubyshell
   - sake
   - thor
+


### PR DESCRIPTION
See: https://github.com/albertalef/rubyshell

Thanks for contributing to the Ruby Toolbox catalog! <3

**Before submitting your pull request:**

- [ ] If you're referencing a gem by its GitHub repository (e.g. `rails/rails`), please verify
      that it is _not_ packaged as a Ruby gem. (If it _is_ packaged as a gem, please reference it
      by its gem name instead, e.g. `rails`.)
- [ ] Make sure the CI build passes, we validate your proposed changes in the test suite :)
