### PR TITLE
Add rails_error_dashboard to Exception Notification category

### DIFF
--- a/catalog/Maintenance_Monitoring/exception_notification.yml
+++ b/catalog/Maintenance_Monitoring/exception_notification.yml
@@ -11,6 +11,7 @@ projects:
   - honeybadger
   - lilypad
   - rack_hoptoad
+  - rails_error_dashboard
   - rails_exception_handler
   - raygun4ruby
   - rollbar


### PR DESCRIPTION
## Summary

Adds [rails_error_dashboard](https://rubygems.org/gems/rails_error_dashboard) to the **Exception Notification** category.

`rails_error_dashboard` is an actively maintained, self-hosted error tracking engine for Ruby on Rails. Key highlights:

- **1,900+ RSpec tests** plus integration chaos tests across 4 real Rails apps
- **CQRS architecture** (Commands/Queries/Services) for clean separation of concerns
- **100+ configuration options** for flexible setup
- **Multi-channel notifications**: Email, Slack, Microsoft Teams, Discord, PagerDuty, custom webhooks
- **Rails Engine** — runs inside the host app's process with zero external service dependencies
- **Broad compatibility**: Ruby 3.2+ (including 4.0), Rails 7.0–8.1
- **Rich dashboard** with error analytics, trend charts, resolution tracking, and cause chain visualization

RubyGems: https://rubygems.org/gems/rails_error_dashboard
GitHub: https://github.com/AnjanJ/rails_error_dashboard

---

**Checklist per PR template:**

- [x] Referenced by gem name (`rails_error_dashboard`), not GitHub repository — it is published as a Ruby gem
- [x] Alphabetical order maintained in the projects list