### PR TITLE
Added Zizq to the catalog for background processing & scheduling.

### DIFF
--- a/catalog/Background_Processing/Background_Jobs.yml
+++ b/catalog/Background_Processing/Background_Jobs.yml
@@ -44,3 +44,4 @@ projects:
   - sucker_punch
   - workling
   - solid_queue
+  - zizq

--- a/catalog/Background_Processing/scheduling.yml
+++ b/catalog/Background_Processing/scheduling.yml
@@ -15,3 +15,4 @@ projects:
   - simple_scheduler
   - Swirrl/Taskit
   - whenever
+  - zizq


### PR DESCRIPTION
Zizq is a background job queue based on a journaled LSM-tree database (no Redis or Postgres etc). Adding to the end of the list, which I assume should be ordered alphabetically? Is `solid_queue` (existing entry) in the wrong position and should it be moved to its alphabetic position?