### PR TITLE
Add fulgur to PDF Generation category

### DIFF
--- a/catalog/Documents_Reports/pdf_generation.yml
+++ b/catalog/Documents_Reports/pdf_generation.yml
@@ -6,6 +6,7 @@ projects:
   - breezy_pdf_lite
   - combine_pdf
   - doc_raptor
+  - fulgur
   - gambas
   - gimli
   - grover


### PR DESCRIPTION
Adds [`fulgur`](https://rubygems.org/gems/fulgur) to the **PDF Generation** category.

fulgur is an offline HTML/CSS → PDF rendering engine (Rust core with Ruby bindings via rb-sys). It generates PDFs server-side without a headless browser (no Chromium/WebKit), aiming for low memory usage and deterministic, reproducible output. It fits alongside the existing HTML-to-PDF entries in this category such as `wkhtmltopdf`, `pdfkit`, `wicked_pdf`, and `grover`.

- RubyGems: https://rubygems.org/gems/fulgur
- Source: https://github.com/fulgur-rs/fulgur

Inserted in alphabetical order between `doc_raptor` and `gambas`.