### PR TITLE
Add AI Agent Skills and Knowledge category

### DIFF
--- a/catalog/Machine_Learning/AI_Agent_Skills.yml
+++ b/catalog/Machine_Learning/AI_Agent_Skills.yml
@@ -1,0 +1,7 @@
+name: AI Agent Skills and Knowledge
+description: Libraries that package project knowledge and reusable skills so AI coding agents can read them
+projects:
+  - agent_skill_parser
+  - bundler-skills
+  - okf
+  - ruby_llm-skills


### PR DESCRIPTION
Adds a category for gems that package knowledge and reusable skills for AI coding agents to read. Four gems qualify today, so it clears the two-entry bar:

- `agent_skill_parser` parses skill files (YAML frontmatter plus Markdown body).
- `bundler-skills` finds `skills/` directories inside your dependency gems and links them into the project's agent skills directory.
- `ruby_llm-skills` loads and validates Agent Skills for RubyLLM.
- `okf` reads, validates, lints, searches, and serves Open Knowledge Format bundles, the Markdown plus YAML format an agent reads project knowledge from. I maintain this one, which is what prompted the PR, but it is not the reason for the category.

I put it under Machine Learning because that is the closest existing group. Developer Tools is arguable, and a separate AI group would be another option if more of these land. Rename or move it as you see fit.

Checklist from the template: all four are published gems, referenced by gem name rather than GitHub path.

I could not run the suite locally since my Ruby is 4.0.5 and `.ruby-version` pins 3.4.1. Instead I checked the three things the specs assert, by loading the whole catalog the way `lib/catalog.rb` does: the shape validates against `json-schema.yml` (30 groups, 219 categories, permalinks and project names matching their patterns), the new category has no duplicates, and all four gem names resolve on RubyGems.
