### PR TITLE
Add name_bank to Random Data Generation

### DIFF
--- a/catalog/Testing/random_data_generation.yml
+++ b/catalog/Testing/random_data_generation.yml
@@ -7,6 +7,7 @@ projects:
   - faker
   - ffaker
   - forgery
+  - name_bank
   - randexp
   - random_data
   - well_read_faker


### PR DESCRIPTION
Adds [name_bank](https://rubygems.org/gems/name_bank) to Random Data Generation.

It generates gender-matched given names and surnames for 106 countries, addressed by ISO alpha-2 country code, with native-script pools for 35 of them. Sampling is deterministic from a caller-supplied RNG, and it has no runtime dependencies.

- [x] Referenced by gem name (it is packaged as a gem: https://rubygems.org/gems/name_bank)
- [x] Entry inserted alphabetically, category unchanged otherwise