### PR TITLE
Add rails_iam gem to Rails Authorization

### DIFF
--- a/catalog/Security/rails_authorization.yml
+++ b/catalog/Security/rails_authorization.yml
@@ -27,6 +27,7 @@ projects:
   - permisi
   - pundit
   - rabarber
+  - rails_iam
   - rails-auth
   - rend-acl
   - restful_acl


### PR DESCRIPTION
### Description
This Pull Request adds the `rails_iam` gem to the **Rails Authorization** category (`catalog/Security/rails_authorization.yml`).

### Motivation
`rails_iam` is a library designed for managing identity and access management/authorization workflows within Ruby on Rails applications. Adding it here will help developers discover it when looking for Rails authorization solutions.

---

Thanks for contributing to the Ruby Toolbox catalog! <3

**Before submitting your pull request:**

- [x] If you're referencing a gem by its GitHub repository (e.g. `rails/rails`), please verify
      that it is _not_ packaged as a Ruby gem. (If it _is_ packaged as a gem, please reference it
      by its gem name instead, e.g. `rails`.) 
      *(Note: Verified. We are referencing `rails_iam` by its actual RubyGems name).*
- [x] Make sure the CI build passes, we validate your proposed changes in the test suite :)
