### PR TITLE
Add Minitest Extensions category

### DIFF
--- a/catalog/Testing/Minitest_Extensions.yml
+++ b/catalog/Testing/Minitest_Extensions.yml
@@ -1,0 +1,18 @@
+name: Minitest Extensions
+description: Plugins and extensions that add functionality to the Minitest test framework,
+  such as alternative assertion syntax, lifecycle hooks, test selection and reporting
+projects:
+  - minitest-around
+  - minitest-bisect
+  - minitest-focus
+  - minitest-global_expectations
+  - minitest-heat
+  - minitest-hooks
+  - minitest-power_assert
+  - minitest-proveit
+  - minitest-rails
+  - minitest-reporters
+  - minitest-rg
+  - minitest-should_just_work
+  - minitest-spec-rails
+  - minitest-sprint


### PR DESCRIPTION
Minitest plugins are currently scattered or uncategorized: a few sit in functional categories (minitest-substitute in Mocking, minitest-flash in Continuous Testing, minitest-cc in Code Coverage), but the bulk of the well-known ones - minitest-reporters, minitest-hooks, minitest-focus, minitest-rg and others - have no category at all.

The existing "Test::Unit Extensions" category is the closest fit, but three of its four entries (contest, pending, jm/context) patch Test::Unit directly and do not work under Minitest, and jm/context's repository no longer exists. Only shoulda supports both frameworks.

All 14 projects seeded here are currently uncategorized, so nothing is moved out of an existing category. Gems that belong in a functional category instead (e.g. minitest-mock_expectations in Mocking) were left out.

Thanks for contributing to the Ruby Toolbox catalog! <3

**Before submitting your pull request:**

- [x] If you're referencing a gem by its GitHub repository (e.g. `rails/rails`), please verify
      that it is _not_ packaged as a Ruby gem. (If it _is_ packaged as a gem, please reference it
      by its gem name instead, e.g. `rails`.)
- [x] Make sure the CI build passes, we validate your proposed changes in the test suite :)
