### PR TITLE
Add i18n_proofreading to I18n

### DIFF
--- a/catalog/Time_Space/i18n.yml
+++ b/catalog/Time_Space/i18n.yml
@@ -20,6 +20,7 @@ projects:
   - i18n
   - i18n-inflector-rails
   - i18n-js
+  - i18n_proofreading
   - i18n-tasks
   - i18n_auto_scoping
   - i18n_routing


### PR DESCRIPTION
https://github.com/yshmarov/i18n_proofreading

Adds the packaged `i18n_proofreading` gem to the existing I18n category. It provides an in-app Rails workflow for reviewing and correcting translations.

- [x] Referenced by RubyGems name
- [x] `bundle exec rspec` passes locally (222 examples)
- [x] `bundle exec rubocop` passes locally