### PR TITLE
Add Product Feedback category

### DIFF
--- a/catalog/Rails_Plugins/product_feedback.yml
+++ b/catalog/Rails_Plugins/product_feedback.yml
@@ -1,0 +1,7 @@
+name: Product Feedback
+description: Collect and manage bug reports, feature requests, and other product feedback from within Rails applications.
+projects:
+  - bug_reports_client
+  - ideasbugs
+  - pivotal_reporter
+  - whatnow


### PR DESCRIPTION
Creates a Rails Plugins category for gems that collect bug reports, feature requests, and other product feedback inside Rails applications.

The category starts with four packaged gems that address this workflow: `bug_reports_client`, `ideasbugs`, `pivotal_reporter`, and `whatnow`.

- [x] All projects are referenced by RubyGems name
- [x] Category has multiple relevant entries
- [x] `bundle exec rspec` passes locally (223 examples)