### PR TITLE
Add Customer Testimonials category

### DIFF
--- a/catalog/Rails_Plugins/customer_testimonials.yml
+++ b/catalog/Rails_Plugins/customer_testimonials.yml
@@ -1,0 +1,5 @@
+name: Customer Testimonials
+description: Collect and publish customer testimonials in Rails applications.
+projects:
+  - refinerycms-testimonials
+  - testimonials


### PR DESCRIPTION
Creates a Rails Plugins category for gems that collect and publish customer testimonials.

The initial packaged entries are `refinerycms-testimonials` and `testimonials` https://github.com/yshmarov/testimonials.

- [x] Both projects are referenced by RubyGems name
- [x] Category has multiple relevant entries
- [x] `bundle exec rspec` passes locally (223 examples)