### PR TITLE
Add Live Chat category

### DIFF
--- a/catalog/Rails_Plugins/live_chat.yml
+++ b/catalog/Rails_Plugins/live_chat.yml
@@ -1,0 +1,8 @@
+name: Live Chat
+description: Add customer-facing live chat to Rails applications, either self-hosted or through a third-party service.
+projects:
+  - gosquared-rails
+  - intercom-rails
+  - livechat
+  - tawk_rails
+  - zopim_rails


### PR DESCRIPTION
Creates a Rails Plugins category for customer-facing live chat, covering both self-hosted implementations and Rails integrations for hosted services.

The initial packaged entries are `gosquared-rails`, `intercom-rails`, `livechat`, `tawk_rails`, and `zopim_rails`.

- [x] All projects are referenced by RubyGems name
- [x] Category has multiple relevant entries
- [x] `bundle exec rspec` passes locally (223 examples)