### PR TITLE
Add Product Guides category

### DIFF
--- a/catalog/Rails_Plugins/product_guides.yml
+++ b/catalog/Rails_Plugins/product_guides.yml
@@ -1,0 +1,12 @@
+name: Product Guides
+description: Build in-app tutorials, onboarding guides, and product walkthroughs for Rails applications, whether content-driven or anchored to page elements.
+projects:
+  - bootstrap-tour-rails
+  - hopscotch-rails
+  - introjs-rails
+  - onboard_on_rails
+  - product_tours
+  - rails_shepherd
+  - shepherd-rails
+  - shepherdjs_rails
+  - turbo_tour


### PR DESCRIPTION
Creates a Rails Plugins category for in-app tutorials, onboarding guides, and product walkthroughs. The description deliberately covers both content-driven guides and page-anchored tours; projects do not need to implement both interaction styles.

The initial list includes nine packaged Rails options: `bootstrap-tour-rails`, `hopscotch-rails`, `introjs-rails`, `onboard_on_rails`, `product_tours`, `rails_shepherd`, `shepherd-rails`, `shepherdjs_rails`, and `turbo_tour`.

- [x] All projects are referenced by RubyGems name
- [x] Category has multiple relevant entries
- [x] `bundle exec rspec` passes locally (223 examples)